### PR TITLE
fix reveal

### DIFF
--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -293,9 +293,9 @@ const emplaceBoardFog = (game: { board: Piece[][] }, playerIndex: number) => {
     const enemyHasFieldMarshall = myBoard.some((row: Piece[]) =>
         row.some((space: Piece | null) => {
             return (
-                space !== null &&
+                space != null &&
                 space.affiliation !== playerIndex &&
-                space.name === 'fieldMarshall'
+                space.name === 'field_marshall'
             );
         }),
     );


### PR DESCRIPTION
# Description

The flag was always being revealed through fog of war because we were using the wrong name to search for a player's existing field marshall.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Unit/integration tests
- [x] Documentation
