### PR TITLE
Add Render deploy config, run production build in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,8 @@ RUN npm install && npm cache clean --force
 
 ENV PATH=./node_modules/.bin:$PATH
 
-# Running default command 
-CMD ["npm", "run", "dev"]
+# Compile TypeScript for production
+RUN npm run build
+
+# Running default command
+CMD ["npm", "run", "prod"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
         depends_on:
             - mongodb
         build: .
+        command: npm run dev
         restart: unless-stopped
         env_file: ./.env
         ports:

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,24 @@
+services:
+  - type: web
+    name: luzhanqi-backend
+    runtime: docker
+    plan: free
+    branch: main
+    autoDeploy: true
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: MONGODB_URI
+        sync: false
+
+  - type: web
+    name: luzhanqi-backend-staging
+    runtime: docker
+    plan: free
+    branch: staging
+    autoDeploy: true
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: MONGODB_URI
+        sync: false


### PR DESCRIPTION
## Summary
- Heroku dropped its free tier; this switches hosting to Render.
- Dockerfile now compiles TypeScript (`npm run build`) and runs the production start script (`npm run prod`) by default.
- docker-compose overrides the command back to `npm run dev` so local development is unaffected.
- Adds `render.yaml` Blueprint defining two web services (`luzhanqi-backend` on `main`, `luzhanqi-backend-staging` on `staging`), free plan, with `MONGODB_URI` left as a manually-set secret per service.

## Test plan
- [x] `docker build` succeeds and compiles TS
- [x] Container runs `npm run prod`, listens on `$PORT`, serves `/` with 200
- [ ] Render Blueprint deploy succeeds for both services once `MONGODB_URI` secrets are set in the dashboard