### PR TITLE
Add session reconnection and single-player vs AI mode

### DIFF
--- a/src/controllers/gameController.test.ts
+++ b/src/controllers/gameController.test.ts
@@ -1,0 +1,51 @@
+import { sanitizeGameForClient, generateToken } from './gameController';
+
+describe('generateToken', () => {
+    test('produces a non-empty, non-guessable, unique string each call', () => {
+        const a = generateToken();
+        const b = generateToken();
+        expect(a).toEqual(expect.any(String));
+        expect(a.length).toBeGreaterThanOrEqual(16);
+        expect(a).not.toEqual(b);
+    });
+});
+
+describe('sanitizeGameForClient', () => {
+    const rawGame = {
+        room: 'abc',
+        players: ['host', 'guest'],
+        playerToSocketIdMap: new Map([['host', 'socket-1']]),
+        playerToUidMap: new Map([['host', 'uid-1']]),
+        playerToTokenMap: new Map([['host', 'super-secret-token']]),
+        spectatorToUidMap: new Map(),
+        spectatorToSocketIdMap: new Map(),
+        turn: 0,
+        board: null,
+    };
+
+    test('strips internal identity maps from a plain object', () => {
+        const sanitized = sanitizeGameForClient(rawGame);
+        expect(sanitized.playerToTokenMap).toBeUndefined();
+        expect(sanitized.playerToUidMap).toBeUndefined();
+        expect(sanitized.playerToSocketIdMap).toBeUndefined();
+        expect(sanitized.spectatorToUidMap).toBeUndefined();
+        expect(sanitized.spectatorToSocketIdMap).toBeUndefined();
+        // safe fields survive
+        expect(sanitized.room).toBe('abc');
+        expect(sanitized.players).toEqual(['host', 'guest']);
+    });
+
+    test('strips internal identity maps from a Mongoose-document-like object', () => {
+        const doc = {
+            toObject: () => rawGame,
+        };
+        const sanitized = sanitizeGameForClient(doc);
+        expect(sanitized.playerToTokenMap).toBeUndefined();
+        expect(sanitized.room).toBe('abc');
+    });
+
+    test('never leaks a reconnection token under any key', () => {
+        const sanitized = sanitizeGameForClient(rawGame);
+        expect(JSON.stringify(sanitized)).not.toContain('super-secret-token');
+    });
+});

--- a/src/controllers/gameController.ts
+++ b/src/controllers/gameController.ts
@@ -1,4 +1,35 @@
+import crypto from 'crypto';
 import Game, { GameConfigData } from '../models/Game';
+import { AI_PLAYER_NAME, AI_SOCKET_SENTINEL } from '../utils/aiConstants';
+
+/**
+ * generates an opaque random token used to prove ownership of a player's
+ * seat when reconnecting to a game (see addClient/playerRejoinRoom)
+ * @see generateToken
+ */
+export const generateToken = (): string => crypto.randomBytes(16).toString('hex');
+
+/**
+ * strips server-internal identity maps (socket ids, uids, reconnection
+ * tokens) from a game object before it is sent to any client. Accepts
+ * either a Mongoose document or a plain object (e.g. the fogged clone
+ * produced by emplaceBoardFog).
+ * @see sanitizeGameForClient
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const sanitizeGameForClient = (game: any) => {
+    const plainGame =
+        typeof game?.toObject === 'function' ? game.toObject() : game;
+    const {
+        playerToTokenMap: _playerToTokenMap,
+        playerToUidMap: _playerToUidMap,
+        playerToSocketIdMap: _playerToSocketIdMap,
+        spectatorToUidMap: _spectatorToUidMap,
+        spectatorToSocketIdMap: _spectatorToSocketIdMap,
+        ...safeFields
+    } = plainGame;
+    return safeFields;
+};
 
 /**
  * creates a Game in the database and returns
@@ -11,25 +42,35 @@ export const createGame = async ({
     host,
     playerToUidMap,
     playerToSocketIdMap,
-    gameConfig = { fogOfWar: true },
+    gameConfig,
 }: {
     host: string;
     playerToUidMap: Map<string, string | null>;
     playerToSocketIdMap: Map<string, string>;
-    gameConfig: GameConfigData;
+    gameConfig?: Partial<GameConfigData>;
 }) => {
+    // merge onto defaults rather than relying on a parameter default, since a
+    // caller-provided object missing one key (e.g. { opponentType: 'ai' }
+    // with no fogOfWar) would otherwise silently leave that key undefined
+    const resolvedConfig: GameConfigData = {
+        fogOfWar: true,
+        opponentType: 'human',
+        ...gameConfig,
+    };
     const game = new Game({
         players: [host],
         playerToUidMap,
         playerToSocketIdMap,
+        playerToTokenMap: new Map([[host, generateToken()]]),
         spectators: [],
         spectatorToUidMap: new Map(),
         spectatorToSocketIdMap: new Map(),
         moves: [],
         turn: 0,
+        phase: 0,
         board: null,
         winnerId: null,
-        config: gameConfig,
+        config: resolvedConfig,
     });
 
     const savedGame = await game.save();
@@ -39,6 +80,31 @@ export const createGame = async ({
     } else {
         console.error('Game not saved');
     }
+};
+
+/**
+ * fills the second seat with the AI opponent (no real socket) and moves
+ * the game straight to the placement phase
+ * @see addAiPlayer
+ */
+export const addAiPlayer = async (gid: string) => {
+    const myGame = await getGameById(gid);
+    if (!myGame) {
+        console.error('Game not found');
+        return;
+    }
+    const { players, playerToUidMap, playerToSocketIdMap } = myGame;
+    players.push(AI_PLAYER_NAME);
+    playerToUidMap.set(AI_PLAYER_NAME, null);
+    playerToSocketIdMap.set(AI_PLAYER_NAME, AI_SOCKET_SENTINEL);
+
+    await updateGame(gid, {
+        players,
+        playerToUidMap,
+        playerToSocketIdMap,
+        phase: 1,
+    });
+    return getGameById(gid);
 };
 
 export const getGameById = async (gid: string) => {
@@ -102,12 +168,19 @@ export const addClient = async ({
     const myGame = await getGameById(gid);
     if (myGame) {
         // assume only one result, take first one
-        const { players, playerToUidMap, playerToSocketIdMap } = myGame;
+        const { players, playerToUidMap, playerToSocketIdMap, playerToTokenMap } =
+            myGame;
         players.push(playerName);
         playerToUidMap.set(playerName, clientId);
         playerToSocketIdMap.set(playerName, mySocketId);
+        playerToTokenMap.set(playerName, generateToken());
 
-        await updateGame(gid, { players, playerToUidMap, playerToSocketIdMap });
+        await updateGame(gid, {
+            players,
+            playerToUidMap,
+            playerToSocketIdMap,
+            playerToTokenMap,
+        });
         const myUpdatedGame = await getGameById(gid);
         console.info(`Updated game: ${myUpdatedGame}`);
         return myUpdatedGame;
@@ -140,12 +213,19 @@ export const removePlayer = async ({
     const myGame = await getGameById(gid);
     if (myGame) {
         // assume only one result, take first one
-        const { playerToUidMap, playerToSocketIdMap } = myGame;
+        const { playerToUidMap, playerToSocketIdMap, playerToTokenMap } = myGame;
         const players = [myGame.players[0]]; // only the host should remain
         playerToUidMap.delete(playerName);
         playerToSocketIdMap.delete(playerName);
+        // a deliberately-vacated seat's old reconnection token must stop working
+        playerToTokenMap.delete(playerName);
 
-        await updateGame(gid, { players, playerToUidMap, playerToSocketIdMap });
+        await updateGame(gid, {
+            players,
+            playerToUidMap,
+            playerToSocketIdMap,
+            playerToTokenMap,
+        });
         const myUpdatedGame = await getGameById(gid);
         console.info(`Updated game: ${myUpdatedGame}`);
         return myUpdatedGame;

--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -1,4 +1,3 @@
-import { isEqual, cloneDeep } from 'lodash';
 import type { Server, Socket } from 'socket.io';
 import Game, { GameConfigData } from './models/Game';
 import {
@@ -8,28 +7,34 @@ import {
     getPlayers,
     addSpectator,
     getSpectators,
-    isPlayerTurn,
-    getMoveHistory,
-    getDeadPieces,
-    updateBoard,
-    updateGame,
-    winner,
-    deleteGame,
     getGameById,
     removeSpectator,
+    updateGame,
+    sanitizeGameForClient,
+    addAiPlayer,
+    deleteGame,
+    winner,
 } from './controllers/gameController';
 import { addGame, removeGame } from './controllers/userController';
 import {
-    getSuccessors,
-    printBoard,
-    validateSetup,
-    pieces,
-    createPiece,
-} from './utils';
+    applyMove,
+    submitInitialBoard,
+    submitAiInitialBoard,
+    broadcastGameState,
+    getGameStats,
+} from './services/gameplayService';
+import { getSuccessors, emplaceBoardFog } from './utils';
+import { chooseAiMove } from './utils/aiPlayer';
+import { AI_PLAYER_NAME } from './utils/aiConstants';
 import { Board, Piece } from './types';
 
 let io: Server;
 let gameSocket: Socket;
+
+// tracks which (gid, playerName) seat a live socket currently occupies,
+// purely so we can announce a disconnect to the room - reconnection itself
+// is handled by the DB-backed token, not this in-memory registry.
+const socketSeatRegistry = new Map<string, { gid: string; playerName: string }>();
 
 export const initGame = (sio: Server, socket: Socket) => {
     io = sio;
@@ -42,6 +47,7 @@ export const initGame = (sio: Server, socket: Socket) => {
 
     // Player Events
     gameSocket.on('playerJoinRoom', playerJoinRoom);
+    gameSocket.on('playerRejoinRoom', playerRejoinRoom);
     gameSocket.on('playerLeaveRoom', playerLeaveRoom);
     gameSocket.on('playerRestart', playerRestart);
     gameSocket.on('playerMakeMove', playerMakeMove);
@@ -54,6 +60,9 @@ export const initGame = (sio: Server, socket: Socket) => {
 
     // Utility Events
     gameSocket.on('pieceSelection', pieceSelection);
+
+    // Connection Events
+    gameSocket.on('disconnect', playerDisconnect);
 };
 
 /* *******************************
@@ -74,7 +83,7 @@ async function hostCreateNewGame(
     }: {
         playerName: string;
         hostId: string | null;
-        gameConfig: GameConfigData;
+        gameConfig?: Partial<GameConfigData>;
     },
 ) {
     const myGame = await createGame({
@@ -86,17 +95,31 @@ async function hostCreateNewGame(
     if (myGame) {
         // MongoDB ObjectIds are BSON by default, ensure roomIds are always strings
         const string_gid = myGame._id.toString();
+
+        // Join the room and wait for the players
+        this.join(string_gid);
+        socketSeatRegistry.set(this.id, { gid: string_gid, playerName });
+
+        let finalGame = myGame;
+        if (gameConfig?.opponentType === 'ai') {
+            const withAi = await addAiPlayer(string_gid);
+            if (withAi) {
+                finalGame = withAi;
+                await submitAiInitialBoard(string_gid);
+            }
+        }
+
         this.emit('newGameCreated', {
             gameId: string_gid,
             mySocketId: this.id,
-            players: await getPlayers(string_gid),
+            players: finalGame.players,
+            phase: finalGame.phase,
+            token: finalGame.playerToTokenMap.get(playerName),
         });
         console.info(
             `New game created with ID: ${string_gid} at socket: ${this.id}`,
         );
 
-        // Join the room and wait for the players
-        this.join(string_gid);
         // Add the Game _id to the host's User document if they are logged in
         hostId && (await addGame(hostId, string_gid));
     } else {
@@ -118,13 +141,11 @@ async function hostPrepareGame(
         roomId: gid,
         turn: 0,
     };
+    const updateFields: Record<string, unknown> = { phase: 1 };
     if (gameConfig) {
-        await Game.findByIdAndUpdate(
-            gid,
-            { $set: { config: gameConfig } },
-            { new: true },
-        );
+        updateFields.config = gameConfig;
     }
+    await Game.findByIdAndUpdate(gid, { $set: updateFields }, { new: true });
     console.info(`All players present. Preparing game for room ${gid}`);
     io.sockets.in(gid).emit('beginNewGame', data);
 }
@@ -195,7 +216,15 @@ async function playerJoinRoom(
             }
             data.players = players;
             data.spectators = spectators || [];
-            this.emit('youHaveJoinedTheRoom', data);
+            socketSeatRegistry.set(this.id, {
+                gid: data.joinRoomId,
+                playerName: data.playerName,
+            });
+            this.emit('youHaveJoinedTheRoom', {
+                ...data,
+                token: myUpdatedGame.playerToTokenMap.get(data.playerName),
+                phase: myUpdatedGame.phase,
+            });
             io.sockets.in(data.joinRoomId).emit('playerJoinedRoom', data);
         } else {
             console.error('Player could not be added to given game');
@@ -204,6 +233,92 @@ async function playerJoinRoom(
             ]);
         }
     }
+}
+
+/**
+ * A player's browser reconnected (page reload, closed tab reopened, etc).
+ * Reclaims their seat if the provided token matches the one issued when
+ * they originally joined, then sends them a full snapshot of the game.
+ */
+async function playerRejoinRoom(
+    this: Socket,
+    {
+        gameId,
+        playerName,
+        token,
+    }: { gameId: string; playerName: string; token: string },
+) {
+    console.info(
+        `Player ${playerName} attempting to rejoin room: ${gameId} on socket id: ${this.id}`,
+    );
+
+    const myGame = await getGameById(gameId);
+    if (!myGame) {
+        this.emit('rejoinFailed', { gameId, reason: 'game-not-found' });
+        return;
+    }
+    if (
+        !myGame.players.includes(playerName) ||
+        myGame.playerToTokenMap.get(playerName) !== token
+    ) {
+        this.emit('rejoinFailed', { gameId, reason: 'invalid-session' });
+        return;
+    }
+
+    myGame.playerToSocketIdMap.set(playerName, this.id);
+    await updateGame(gameId, {
+        playerToSocketIdMap: myGame.playerToSocketIdMap,
+    });
+    this.join(gameId);
+    socketSeatRegistry.set(this.id, { gid: gameId, playerName });
+
+    const playerIndex = myGame.players.indexOf(playerName);
+    const boardComplete = Array.isArray(myGame.board) && myGame.board.length === 12;
+    let board = null;
+    let deadPieces: unknown[] = [];
+    if (boardComplete) {
+        const view = myGame.config.fogOfWar
+            ? emplaceBoardFog(
+                  myGame as unknown as { board: Piece[][]; deadPieces: Piece[] },
+                  playerIndex,
+              )
+            : myGame;
+        board = view.board;
+        deadPieces = view.deadPieces;
+    }
+
+    let winnerIndex: number | null = null;
+    let gameStats = null;
+    if (myGame.phase === 3 && boardComplete) {
+        winnerIndex = await winner(gameId);
+        gameStats = await getGameStats(gameId);
+    }
+
+    this.emit('youHaveRejoinedTheRoom', {
+        gameId,
+        playerName,
+        players: myGame.players,
+        spectators: myGame.spectators,
+        phase: myGame.phase,
+        turn: myGame.turn,
+        board,
+        deadPieces,
+        submittedSide: myGame.playersSubmittedSetup?.includes(playerName) ?? false,
+        winnerIndex,
+        gameStats,
+    });
+    io.sockets.in(gameId).emit('playerReconnected', { playerName });
+}
+
+function playerDisconnect(this: Socket) {
+    const seat = socketSeatRegistry.get(this.id);
+    if (!seat) {
+        return;
+    }
+    socketSeatRegistry.delete(this.id);
+    io.sockets.in(seat.gid).emit('playerDisconnected', {
+        playerName: seat.playerName,
+    });
 }
 
 /**
@@ -234,6 +349,8 @@ async function playerLeaveRoom(
     console.info(`Room: ${data.leaveRoomId}`);
 
     const myGame = await getGameById(data.leaveRoomId);
+
+    socketSeatRegistry.delete(this.id);
 
     if (myGame?.board) {
         // board has already been set, do not delete the Game
@@ -451,54 +568,6 @@ async function spectatorLeaveRoom(
     }
 }
 
-const emplaceBoardFog = (
-    game: { board: Piece[][]; deadPieces: Piece[] },
-    playerIndex: number,
-) => {
-    // copy the board because we are diverging them
-    const myBoard = cloneDeep(game.board);
-    const enemyHasFieldMarshall = myBoard.some((row: Piece[]) =>
-        row.some((space: Piece | null) => {
-            return (
-                space != null &&
-                space.affiliation !== playerIndex &&
-                space.name === 'field_marshall'
-            );
-        }),
-    );
-
-    const myDeadPieces = game.deadPieces.filter(
-        (piece) => piece.affiliation == playerIndex,
-    );
-
-    myBoard.forEach((row: Piece[], y: number) => {
-        // for each space
-        row.forEach((space: Piece | null, x: number) => {
-            // only replace pieces that are there
-            if (space !== null && space.affiliation !== playerIndex) {
-                // reveal flag if field marshall is captured
-                const isRevealedFlag =
-                    space.name === 'flag' && !enemyHasFieldMarshall;
-
-                // hide piece if is enemy piece and not revealed flag
-                if (!isRevealedFlag) {
-                    myBoard[y][x] = {
-                        0: y,
-                        1: x,
-                        length: 2,
-                        ...createPiece('enemy', 1 - playerIndex), // indicate the affiliation as opposite of oneself
-                    };
-                }
-            }
-        });
-    });
-    const myGame = cloneDeep(game);
-    myGame.board = myBoard;
-    myGame.deadPieces = myDeadPieces;
-    printBoard(myBoard);
-    return myGame;
-};
-
 async function playerInitialBoard(
     this: Socket,
     {
@@ -507,109 +576,21 @@ async function playerInitialBoard(
         room: gid,
     }: {
         playerName: string;
-        myPositions: [][];
+        myPositions: Board;
         room: string;
     },
 ) {
     console.info(`playerInitialBoard from ${playerName} on socket ${this.id}`);
-    let myGame = await getGameById(gid);
-    if (!myGame) {
-        console.error('Game not found.');
-        this.emit('error', [`$Game not found: ${gid}`]);
+    const result = await submitInitialBoard(gid, playerName, myPositions);
+    if (!result.ok) {
+        this.emit('error', result.errors || [result.reason]);
         return;
     }
-    const playerIndex = myGame.players.indexOf(playerName);
-    if (myGame.board === null) {
-        let halfGameBoard;
-        if (playerIndex === 0) {
-            // the host
-            console.info('Confirmed host');
-            halfGameBoard = myPositions;
-        } else {
-            // the guest
-            halfGameBoard = myPositions.reverse();
-        }
-        const [isValid, validationErrorStack] = validateSetup(
-            halfGameBoard,
-            !playerIndex,
-        );
-        if (!isValid) {
-            console.error(validationErrorStack.join(', \n'));
-            this.emit('error', validationErrorStack);
-            return;
-        }
-        await updateBoard(gid, halfGameBoard);
+    if (!result.complete) {
         this.emit('halfBoardReceived');
-    } else if (myGame.board.length === 6) {
-        // only half of the board is filled
-        let completeGameBoard;
-        if (playerIndex === 0) {
-            // the host
-            completeGameBoard = myGame.board.concat(myPositions);
-        } else if (playerIndex === 1) {
-            // the guest
-            completeGameBoard = myPositions
-                .reverse()
-                .concat(myGame.board as [][]);
-        }
-        await updateBoard(gid, completeGameBoard);
-        myGame = await getGameById(gid);
-
-        if (!myGame) {
-            console.error('Game not found.');
-            this.emit('error', [`$Game not found: ${gid}`]);
-            return;
-        }
-
-        myGame.playerToSocketIdMap.forEach(
-            (socketId: string, instPlayerName: string) => {
-                console.info(
-                    `Sending board to player ${instPlayerName} on socket: ${socketId}`,
-                );
-
-                if (!myGame) {
-                    console.error('Game not found.');
-                    this.emit('error', [`$Game not found: ${gid}`]);
-                    return;
-                }
-
-                const playerIndex = myGame.players.indexOf(instPlayerName);
-                console.info(`playerIndex: ${playerIndex}`);
-
-                io.to(socketId).emit(
-                    'boardSet',
-                    myGame.config.fogOfWar
-                        ? emplaceBoardFog(
-                              myGame as unknown as {
-                                  board: Piece[][];
-                                  deadPieces: Piece[];
-                              },
-                              playerIndex,
-                          )
-                        : myGame,
-                );
-            },
-        );
-        myGame.spectatorToSocketIdMap.forEach(
-            (socketId: string, instSpectatorName: string) => {
-                console.info(
-                    `Sending board to spectator ${instSpectatorName} on socket: ${socketId}`,
-                );
-
-                if (!myGame) {
-                    console.error('Game not found.');
-                    this.emit('error', [`$Game not found: ${gid}`]);
-                    return;
-                }
-
-                const spectatorIndex =
-                    myGame.spectators.indexOf(instSpectatorName);
-                console.info(`spectatorIndex: ${spectatorIndex}`);
-
-                io.to(socketId).emit('boardSet', myGame);
-            },
-        );
+        return;
     }
+    await broadcastGameState(io, result.game, 'boardSet');
 }
 
 async function pieceSelection(
@@ -620,7 +601,7 @@ async function pieceSelection(
         playerName,
         room: gid,
     }: {
-        board: [][];
+        board: Board;
         piece: number[];
         playerName: string;
         room: string;
@@ -639,130 +620,6 @@ async function pieceSelection(
     this.emit('pieceSelected', successors);
 }
 
-// returns a new board
-function pieceMovement(board: Board, source: Piece, target: Piece) {
-    // copy the board
-    board = cloneDeep(board);
-    const deadPieces: Piece[] = [];
-
-    if (!source.length || !target.length) {
-        return { board, deadPieces };
-    }
-
-    const sourcePiece = board[source[0]][source[1]];
-    const targetPiece = board[target[0]][target[1]];
-
-    // there is no piece at the source tile (not a valid move)
-    if (
-        sourcePiece === null ||
-        sourcePiece.name === 'landmine' ||
-        sourcePiece.name === 'flag'
-    ) {
-        return { board, deadPieces };
-    }
-
-    // pieces are of same affiliation
-    if (targetPiece && sourcePiece.affiliation === targetPiece.affiliation) {
-        return { board, deadPieces };
-    }
-
-    if (
-        targetPiece &&
-        (sourcePiece.name === 'bomb' ||
-            sourcePiece.name === targetPiece.name ||
-            targetPiece.name === 'bomb' ||
-            (sourcePiece.name !== 'engineer' &&
-                targetPiece.name === 'landmine'))
-    ) {
-        // remove both pieces
-        deadPieces.push(
-            board[target[0]][target[1]] as Piece,
-            board[source[0]][source[1]] as Piece,
-        );
-        board[target[0]][target[1]] = null;
-        board[source[0]][source[1]] = null;
-    } else if (
-        targetPiece === null ||
-        sourcePiece.order > targetPiece.order ||
-        (sourcePiece.name === 'engineer' && targetPiece.name === 'landmine')
-    ) {
-        // place source piece on target tile, remove source piece from source tile
-        if (sourcePiece) {
-            deadPieces.push(sourcePiece);
-        }
-        board[target[0]][target[1]] = sourcePiece;
-        board[source[0]][source[1]] = null;
-    } else {
-        // kill source piece only
-        deadPieces.push(board[source[0]][source[1]] as Piece);
-        board[source[0]][source[1]] = null;
-    }
-    return { board, deadPieces };
-}
-
-// return game stats in the form of a nested array
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getGameStats(this: any, gid: string) {
-    const myGame = await getGameById(gid);
-    if (!myGame?.board) {
-        console.error('Game or game board not found.');
-        this.emit('error', [`$Game or game board not found: ${gid}`]);
-        return;
-    }
-    // get number of pieces killed by each player
-    const emptyPieceArr = [
-        ...Object.keys(pieces).map((piece) => ({
-            name: piece,
-            count: 0,
-            order: pieces[piece].order,
-        })),
-    ];
-
-    const remain = [
-        // deep copies of emptyPieceArr, strongly typed
-        JSON.parse(JSON.stringify(emptyPieceArr)) as [
-            { name: string; count: number; order: number },
-        ],
-        JSON.parse(JSON.stringify(emptyPieceArr)) as [
-            { name: string; count: number; order: number },
-        ],
-    ];
-    myGame.board.forEach((row) => {
-        row.forEach((piece) => {
-            if (piece) {
-                const affiliation = piece.affiliation;
-                const pieceIndex = remain[affiliation].findIndex(
-                    (p) => p.name === piece.name,
-                );
-                remain[affiliation][pieceIndex].count += 1;
-            }
-        });
-    });
-    // get number of pieces killed by each player
-    const lost = [
-        remain[0].map(({ name, order, count: _count }) => {
-            const pieceIndex = remain[0].findIndex((p) => p.name === name);
-            return {
-                name,
-                count: pieces[name].count - remain[0][pieceIndex].count,
-                order,
-            };
-        }),
-        remain[1].map(({ name, order, count: _count }) => {
-            const pieceIndex = remain[1].findIndex((p) => p.name === name);
-            return {
-                name,
-                count: pieces[name].count - remain[1][pieceIndex].count,
-                order,
-            };
-        }),
-    ];
-    return {
-        remain,
-        lost,
-    };
-}
-
 async function playerMakeMove(
     this: Socket,
     {
@@ -773,128 +630,104 @@ async function playerMakeMove(
         pendingMove,
     }: {
         playerName: string;
-        uid: string;
+        uid: string | null;
         room: string;
         turn: number;
         pendingMove: {
-            source: Piece;
-            target: Piece;
+            source: [number, number];
+            target: [number, number];
         };
     },
 ) {
-    if (
-        await isPlayerTurn({
-            playerName,
-            gid,
-            turn,
-        })
-    ) {
-        let myGame = await getGameById(gid);
-        if (!myGame) {
-            console.error('Game not found.');
-            this.emit('error', [`$Game not found: ${gid}`]);
-            return;
-        }
-        const myBoard = myGame.board;
-        const { source, target } = pendingMove;
-        const { board: newBoard, deadPieces } = pieceMovement(
-            myBoard as Board,
-            source,
-            target,
+    const result = await applyMove(gid, playerName, uid || null, turn, pendingMove);
+    if (!result.ok) {
+        this.emit('error', [result.reason]);
+        return;
+    }
+
+    console.info(`Someone made a move, the turn is now ${result.turn}`);
+    await broadcastGameState(io, result.game, 'playerMadeMove');
+
+    if (result.winnerIndex !== -1) {
+        console.info('game ended from victory', result.gameStats);
+        io.sockets.in(gid).emit('endGame', {
+            winnerIndex: result.winnerIndex,
+            gameStats: result.gameStats,
+            finalGame: sanitizeGameForClient(result.game),
+        });
+        return;
+    }
+
+    if (result.game.config.opponentType === 'ai') {
+        scheduleAiTurn(gid, result.turn);
+    }
+}
+
+function scheduleAiTurn(gid: string, turn: number) {
+    // the AI always occupies the second seat
+    const aiPlayerIndex = 1;
+    if (turn % 2 !== aiPlayerIndex) {
+        return;
+    }
+    const delayMs = 400 + Math.random() * 500;
+    setTimeout(() => {
+        runAiTurn(gid, turn).catch((err) =>
+            console.error(`AI turn failed for game ${gid}:`, err),
         );
-        if (isEqual(newBoard, myBoard)) {
-            this.emit('error', ['No move made.']);
-        } else {
-            turn += 1;
-            await updateBoard(gid, newBoard);
-            // print the board
-            printBoard(newBoard);
-            const moveHistory = await getMoveHistory(gid);
-            const deadPieceHistory = await getDeadPieces(gid);
-            if (!moveHistory) {
-                console.error('Move history not found.');
-                this.emit('error', [`$Move history not found: ${gid}`]);
-                return;
-            }
-            await updateGame(gid, {
-                turn,
-                moves: [...moveHistory, pendingMove],
-                deadPieces: [...(deadPieceHistory || []), ...deadPieces],
-            });
-            myGame = await getGameById(gid);
+    }, delayMs);
+}
 
-            if (!myGame) {
-                console.error('Game not found.');
-                this.emit('error', [`$Game not found: ${gid}`]);
-                return;
-            }
+async function runAiTurn(gid: string, turn: number) {
+    const myGame = await getGameById(gid);
+    if (!myGame || !myGame.board) {
+        return;
+    }
+    const aiPlayerIndex = myGame.players.indexOf(AI_PLAYER_NAME);
+    if (aiPlayerIndex === -1) {
+        return;
+    }
 
-            console.info(`Someone made a move, the turn is now ${turn}`);
-            console.info(`Sending back gameState on ${gid}`);
-            myGame.playerToSocketIdMap.forEach(
-                (socketId: string, instPlayerName: string) => {
-                    console.info(
-                        `Sending board to ${instPlayerName} on socket: ${socketId}`,
-                    );
+    const fogged = myGame.config.fogOfWar
+        ? emplaceBoardFog(
+              myGame as unknown as { board: Piece[][]; deadPieces: Piece[] },
+              aiPlayerIndex,
+          )
+        : myGame;
+    const move = chooseAiMove(fogged.board as Board, aiPlayerIndex);
 
-                    if (!myGame) {
-                        console.error('Game not found.');
-                        this.emit('error', [`$Game not found: ${gid}`]);
-                        return;
-                    }
+    if (!move) {
+        // AI has no legal moves - treat it as a forfeit (a pre-existing gap
+        // in winner() means human-vs-human stalemates aren't handled either,
+        // this just makes the case reachable and resolves it the same way)
+        const winnerIndex = aiPlayerIndex === 0 ? 1 : 0;
+        const gameStats = await getGameStats(gid);
+        await updateGame(gid, {
+            winnerId:
+                myGame.playerToUidMap.get(myGame.players[winnerIndex]) ||
+                'anonymous',
+            phase: 3,
+        });
+        io.sockets.in(gid).emit('endGame', { winnerIndex, gameStats });
+        return;
+    }
 
-                    const playerIndex = myGame.players.indexOf(instPlayerName);
-                    console.info(`playerIndex: ${playerIndex}`);
+    const result = await applyMove(gid, AI_PLAYER_NAME, null, turn, {
+        source: move.source,
+        target: move.target,
+    });
+    if (!result.ok) {
+        console.error(`AI move could not be applied for game ${gid}:`, result.reason);
+        return;
+    }
 
-                    io.to(socketId).emit(
-                        'playerMadeMove',
-                        myGame.config.fogOfWar
-                            ? emplaceBoardFog(
-                                  myGame as unknown as {
-                                      board: Piece[][];
-                                      deadPieces: Piece[];
-                                  },
-                                  playerIndex,
-                              )
-                            : myGame,
-                    );
-                },
-            );
-
-            myGame.spectatorToSocketIdMap.forEach(
-                (socketId: string, instSpectatorName: string) => {
-                    console.info(
-                        `Sending board to ${instSpectatorName} on socket: ${socketId}`,
-                    );
-
-                    if (!myGame) {
-                        console.error('Game not found.');
-                        this.emit('error', [`$Game not found: ${gid}`]);
-                        return;
-                    }
-
-                    const spectatorIndex =
-                        myGame.spectators.indexOf(instSpectatorName);
-                    console.info(`spectatorIndex: ${spectatorIndex}`);
-
-                    io.to(socketId).emit('playerMadeMove', myGame);
-                },
-            );
-
-            const winnerIndex = await winner(gid);
-            const gameStats = await getGameStats(gid);
-            if (winnerIndex !== -1) {
-                console.info('game ended from victory', gameStats);
-                io.sockets.in(gid).emit('endGame', {
-                    winnerIndex,
-                    gameStats,
-                    finalGame: myGame,
-                });
-                await updateGame(gid, { winnerId: uid || 'anonymous' });
-            }
-        }
-    } else {
-        this.emit('error', ['It is not your turn.']);
+    await broadcastGameState(io, result.game, 'playerMadeMove');
+    if (result.winnerIndex !== -1) {
+        console.info('game ended from victory (AI)', result.gameStats);
+        io.sockets.in(gid).emit('endGame', {
+            winnerIndex: result.winnerIndex,
+            gameStats: result.gameStats,
+            finalGame: sanitizeGameForClient(result.game),
+        });
     }
 }
 
@@ -915,6 +748,7 @@ async function playerForfeit(
         winnerId:
             myGame.playerToUidMap.get(myGame.players[winnerIndex]) ||
             'anonymous',
+        phase: 3,
     });
 
     const gameStats = await getGameStats(gid);

--- a/src/models/Game.ts
+++ b/src/models/Game.ts
@@ -3,15 +3,20 @@ import { Schema, model, Types, Model } from 'mongoose';
 interface IGameConfig extends Document {
     _id: Types.ObjectId;
     fogOfWar: boolean;
+    opponentType: 'human' | 'ai';
 }
 
-export type GameConfigData = Pick<IGameConfig, 'fogOfWar'>;
+export type GameConfigData = Pick<
+    IGameConfig,
+    'fogOfWar' | 'opponentType'
+>;
 
-interface IGame extends Document {
+export interface IGame extends Document {
     room: string;
     players: Array<string>;
     playerToSocketIdMap: Map<string, string>;
     playerToUidMap: Map<string, string | null>;
+    playerToTokenMap: Map<string, string>;
     spectators: Array<string>;
     spectatorToSocketIdMap: Map<string, string>;
     spectatorToUidMap: Map<string, string | null>;
@@ -20,6 +25,11 @@ interface IGame extends Document {
         target: Array<number>;
     }>;
     turn: number;
+    // 0 waiting for players, 1 setup/placement, 2 gameplay, 3 ended
+    phase: number;
+    // names of players who have already submitted their setup half-board,
+    // since a partial (6-row) board alone can't tell us who submitted it
+    playersSubmittedSetup: Array<string>;
     board: Array<
         Array<{
             name: string;
@@ -51,16 +61,20 @@ const GameSchema = new Schema<IGame, GameModelType>(
         players: [],
         playerToUidMap: Map,
         playerToSocketIdMap: Map,
+        playerToTokenMap: Map,
         spectators: [],
         spectatorToUidMap: Map,
         spectatorToSocketIdMap: Map,
         moves: [],
         turn: Number,
+        phase: { type: Number, default: 0 },
+        playersSubmittedSetup: { type: [String], default: [] },
         board: [],
         deadPieces: [],
         winnerId: String,
         config: new Schema<IGameConfig>({
             fogOfWar: Boolean,
+            opponentType: { type: String, default: 'human' },
         }),
     },
     { timestamps: true },

--- a/src/routes/games/index.ts
+++ b/src/routes/games/index.ts
@@ -3,7 +3,10 @@
 
 import { Router } from 'express';
 // import functions from the controller
-import { getGameById } from '../../controllers/gameController';
+import {
+    getGameById,
+    sanitizeGameForClient,
+} from '../../controllers/gameController';
 
 const games = Router();
 
@@ -12,20 +15,20 @@ const games = Router();
 games.get('/:gameId', async (req, res) => {
     const myGame = await getGameById(req.params.gameId);
     if (myGame) {
-        res.status(200).send(myGame);
+        res.status(200).send(sanitizeGameForClient(myGame));
     } else {
         res.status(404).send('Game not found');
     }
 });
 
 // updates a Game's playerToUidMap with a playerName -> Firebase uid
-games.post('/:gameId/:playerName/:uid', async (req, res) => { 
+games.post('/:gameId/:playerName/:uid', async (req, res) => {
     const { gameId, playerName, uid } = req.params;
     const myGame = await getGameById(gameId);
     if (myGame) {
         myGame.playerToUidMap.set(playerName, uid);
         myGame.save();
-        res.status(200).send(myGame);
+        res.status(200).send(sanitizeGameForClient(myGame));
     } else {
         res.status(404).send('Game not found');
     }

--- a/src/services/gameplayService.ts
+++ b/src/services/gameplayService.ts
@@ -1,0 +1,347 @@
+import { cloneDeep, isEqual } from 'lodash';
+import type { Server } from 'socket.io';
+import { IGame } from '../models/Game';
+import {
+    getGameById,
+    updateBoard,
+    updateGame,
+    getMoveHistory,
+    getDeadPieces,
+    isPlayerTurn,
+    winner,
+    sanitizeGameForClient,
+} from '../controllers/gameController';
+import { pieces, validateSetup, printBoard, emplaceBoardFog } from '../utils';
+import { generateRandomValidHalfBoard } from '../utils/aiSetup';
+import { AI_PLAYER_NAME, AI_SOCKET_SENTINEL } from '../utils/aiConstants';
+import { Board } from '../utils/board';
+import { Piece } from '../utils/piece';
+// emplaceBoardFog's signature predates the clean Piece/Board types above and
+// still expects the legacy shape from types.ts - only used for that cast.
+import { Piece as FoggablePiece } from '../types';
+
+type Coord = [number, number];
+
+// returns a new board with the move applied, and any pieces that died as a result
+export function pieceMovement(board: Board, source: Coord, target: Coord) {
+    // copy the board
+    board = cloneDeep(board);
+    const deadPieces: Piece[] = [];
+
+    if (!source.length || !target.length) {
+        return { board, deadPieces };
+    }
+
+    const sourcePiece = board[source[0]][source[1]];
+    const targetPiece = board[target[0]][target[1]];
+
+    // there is no piece at the source tile (not a valid move)
+    if (
+        sourcePiece === null ||
+        sourcePiece.name === 'landmine' ||
+        sourcePiece.name === 'flag'
+    ) {
+        return { board, deadPieces };
+    }
+
+    // pieces are of same affiliation
+    if (targetPiece && sourcePiece.affiliation === targetPiece.affiliation) {
+        return { board, deadPieces };
+    }
+
+    if (
+        targetPiece &&
+        (sourcePiece.name === 'bomb' ||
+            sourcePiece.name === targetPiece.name ||
+            targetPiece.name === 'bomb' ||
+            (sourcePiece.name !== 'engineer' &&
+                targetPiece.name === 'landmine'))
+    ) {
+        // remove both pieces
+        deadPieces.push(
+            board[target[0]][target[1]] as Piece,
+            board[source[0]][source[1]] as Piece,
+        );
+        board[target[0]][target[1]] = null;
+        board[source[0]][source[1]] = null;
+    } else if (
+        targetPiece === null ||
+        sourcePiece.order > targetPiece.order ||
+        (sourcePiece.name === 'engineer' && targetPiece.name === 'landmine')
+    ) {
+        // place source piece on target tile, remove source piece from source tile
+        if (sourcePiece) {
+            deadPieces.push(sourcePiece);
+        }
+        board[target[0]][target[1]] = sourcePiece;
+        board[source[0]][source[1]] = null;
+    } else {
+        // kill source piece only
+        deadPieces.push(board[source[0]][source[1]] as Piece);
+        board[source[0]][source[1]] = null;
+    }
+    return { board, deadPieces };
+}
+
+export type GameStats = {
+    remain: { name: string; count: number; order: number }[][];
+    lost: { name: string; count: number; order: number }[][];
+};
+
+// returns per-player remaining/lost piece counts, or null if the game/board isn't found
+export async function getGameStats(gid: string): Promise<GameStats | null> {
+    const myGame = await getGameById(gid);
+    if (!myGame?.board) {
+        console.error('Game or game board not found.');
+        return null;
+    }
+    const emptyPieceArr = [
+        ...Object.keys(pieces).map((piece) => ({
+            name: piece,
+            count: 0,
+            order: pieces[piece].order,
+        })),
+    ];
+
+    const remain = [
+        JSON.parse(JSON.stringify(emptyPieceArr)) as [
+            { name: string; count: number; order: number },
+        ],
+        JSON.parse(JSON.stringify(emptyPieceArr)) as [
+            { name: string; count: number; order: number },
+        ],
+    ];
+    myGame.board.forEach((row) => {
+        row.forEach((piece) => {
+            if (piece) {
+                const affiliation = piece.affiliation;
+                const pieceIndex = remain[affiliation].findIndex(
+                    (p) => p.name === piece.name,
+                );
+                remain[affiliation][pieceIndex].count += 1;
+            }
+        });
+    });
+    const lost = [
+        remain[0].map(({ name, order, count: _count }) => {
+            const pieceIndex = remain[0].findIndex((p) => p.name === name);
+            return {
+                name,
+                count: pieces[name].count - remain[0][pieceIndex].count,
+                order,
+            };
+        }),
+        remain[1].map(({ name, order, count: _count }) => {
+            const pieceIndex = remain[1].findIndex((p) => p.name === name);
+            return {
+                name,
+                count: pieces[name].count - remain[1][pieceIndex].count,
+                order,
+            };
+        }),
+    ];
+    return { remain, lost };
+}
+
+export type MoveResult =
+    | {
+          ok: true;
+          game: IGame;
+          turn: number;
+          deadPieces: Piece[];
+          winnerIndex: number;
+          gameStats: GameStats | null;
+      }
+    | { ok: false; reason: string };
+
+/**
+ * Validates and applies a move to a game, persists the result, and checks
+ * for a winner. No socket/io access - safe to call for a human move (from
+ * the playerMakeMove socket handler) or an AI move (from runAiTurn).
+ * @see applyMove
+ */
+export async function applyMove(
+    gid: string,
+    playerName: string,
+    uid: string | null,
+    turn: number,
+    pendingMove: { source: Coord; target: Coord },
+): Promise<MoveResult> {
+    const isTurn = await isPlayerTurn({ playerName, gid, turn });
+    if (!isTurn) {
+        return { ok: false, reason: 'It is not your turn.' };
+    }
+
+    const myGame = await getGameById(gid);
+    if (!myGame) {
+        return { ok: false, reason: 'Game not found.' };
+    }
+
+    const myBoard = myGame.board;
+    const { source, target } = pendingMove;
+    const { board: newBoard, deadPieces } = pieceMovement(
+        myBoard as Board,
+        source,
+        target,
+    );
+    if (isEqual(newBoard, myBoard)) {
+        return { ok: false, reason: 'No move made.' };
+    }
+
+    const newTurn = turn + 1;
+    await updateBoard(gid, newBoard);
+    printBoard(newBoard);
+
+    const moveHistory = await getMoveHistory(gid);
+    const deadPieceHistory = await getDeadPieces(gid);
+    await updateGame(gid, {
+        turn: newTurn,
+        moves: [...(moveHistory || []), pendingMove],
+        deadPieces: [...(deadPieceHistory || []), ...deadPieces],
+    });
+
+    const updatedGame = await getGameById(gid);
+    if (!updatedGame) {
+        return { ok: false, reason: 'Game not found after update.' };
+    }
+
+    const winnerIndex = await winner(gid);
+    const gameStats = await getGameStats(gid);
+    if (winnerIndex !== -1) {
+        await updateGame(gid, { winnerId: uid || 'anonymous', phase: 3 });
+    }
+
+    return {
+        ok: true,
+        game: updatedGame,
+        turn: newTurn,
+        deadPieces,
+        winnerIndex,
+        gameStats,
+    };
+}
+
+export type SetupResult =
+    | { ok: true; complete: false }
+    | { ok: true; complete: true; game: IGame }
+    | { ok: false; reason: string; errors?: string[] };
+
+/**
+ * Validates and stores one player's half-board during the setup/placement
+ * phase, merging the two halves once both have been submitted. No
+ * socket/io access - reused for both human placements and the AI's
+ * generated placement.
+ * @see submitInitialBoard
+ */
+export async function submitInitialBoard(
+    gid: string,
+    playerName: string,
+    myPositions: Board,
+): Promise<SetupResult> {
+    const myGame = await getGameById(gid);
+    if (!myGame) {
+        return { ok: false, reason: 'Game not found.' };
+    }
+    if (myGame.playersSubmittedSetup?.includes(playerName)) {
+        return { ok: false, reason: 'You have already submitted your setup.' };
+    }
+    const playerIndex = myGame.players.indexOf(playerName);
+    const submittedSoFar = myGame.playersSubmittedSetup || [];
+
+    if (myGame.board === null) {
+        const halfGameBoard =
+            playerIndex === 0 ? myPositions : [...myPositions].reverse();
+        const [isValid, validationErrorStack] = validateSetup(
+            halfGameBoard as unknown as Piece[][],
+            !playerIndex,
+        );
+        if (!isValid) {
+            return {
+                ok: false,
+                reason: 'Invalid setup.',
+                errors: validationErrorStack,
+            };
+        }
+        await updateBoard(gid, halfGameBoard);
+        await updateGame(gid, {
+            playersSubmittedSetup: [...submittedSoFar, playerName],
+        });
+        return { ok: true, complete: false };
+    } else if (myGame.board.length === 6) {
+        let completeGameBoard: Board;
+        if (playerIndex === 0) {
+            completeGameBoard = (myGame.board as unknown as Board).concat(
+                myPositions,
+            );
+        } else {
+            completeGameBoard = [...myPositions]
+                .reverse()
+                .concat(myGame.board as unknown as Board);
+        }
+        await updateBoard(gid, completeGameBoard);
+        await updateGame(gid, {
+            phase: 2,
+            playersSubmittedSetup: [...submittedSoFar, playerName],
+        });
+        const updatedGame = await getGameById(gid);
+        if (!updatedGame) {
+            return { ok: false, reason: 'Game not found after update.' };
+        }
+        return { ok: true, complete: true, game: updatedGame };
+    }
+    return { ok: false, reason: 'Unexpected board state.' };
+}
+
+/**
+ * Generates and submits the AI's setup half-board through the same path a
+ * real guest player's placement would take. The AI always occupies seat 1.
+ * @see submitAiInitialBoard
+ */
+export async function submitAiInitialBoard(gid: string): Promise<SetupResult> {
+    const aiHalfBoard = generateRandomValidHalfBoard(1);
+    // submitInitialBoard reverses non-host (playerIndex !== 0) submissions
+    // before validating/storing them, since that's what a real guest
+    // player's raw submission is expected to look like (see the guest
+    // branch below) - pre-reverse here so it round-trips back to the
+    // valid board generateRandomValidHalfBoard actually built.
+    const submissionOrientedBoard = [...aiHalfBoard].reverse();
+    return submitInitialBoard(gid, AI_PLAYER_NAME, submissionOrientedBoard);
+}
+
+/**
+ * Emits a game-state event to every connected player (fogged per-player if
+ * the game has fog of war enabled) and spectator (always unfogged), always
+ * sanitized to strip internal identity maps. Skips the AI's sentinel seat.
+ * @see broadcastGameState
+ */
+export async function broadcastGameState(
+    io: Server,
+    myGame: IGame,
+    eventName: string,
+) {
+    myGame.playerToSocketIdMap.forEach(
+        (socketId: string, instPlayerName: string) => {
+            if (socketId === AI_SOCKET_SENTINEL) {
+                return;
+            }
+            const playerIndex = myGame.players.indexOf(instPlayerName);
+            io.to(socketId).emit(
+                eventName,
+                sanitizeGameForClient(
+                    myGame.config.fogOfWar
+                        ? emplaceBoardFog(
+                              myGame as unknown as {
+                                  board: FoggablePiece[][];
+                                  deadPieces: FoggablePiece[];
+                              },
+                              playerIndex,
+                          )
+                        : myGame,
+                ),
+            );
+        },
+    );
+    myGame.spectatorToSocketIdMap.forEach((socketId: string) => {
+        io.to(socketId).emit(eventName, sanitizeGameForClient(myGame));
+    });
+}

--- a/src/utils/aiConstants.ts
+++ b/src/utils/aiConstants.ts
@@ -1,0 +1,4 @@
+// Sentinel identity for the AI opponent's virtual "seat" in a game.
+// It occupies players[1] like a real guest, but has no real socket connection.
+export const AI_PLAYER_NAME = 'Computer';
+export const AI_SOCKET_SENTINEL = '__ai__';

--- a/src/utils/aiPlayer.test.ts
+++ b/src/utils/aiPlayer.test.ts
@@ -1,0 +1,56 @@
+import { chooseAiMove } from './aiPlayer';
+import { getSuccessors } from './getSuccessors';
+import { emptyBoard, Board } from './board';
+import { createPiece, placePiece } from './piece';
+
+describe('chooseAiMove', () => {
+    test('returns null when the AI has no pieces on the board', () => {
+        const board = emptyBoard();
+        expect(chooseAiMove(board, 0)).toBeNull();
+    });
+
+    test('always returns a move that getSuccessors considers legal', () => {
+        let board = emptyBoard();
+        board = placePiece(board, 6, 0, createPiece('captain', 0));
+        board = placePiece(board, 6, 4, createPiece('major', 0));
+        board = placePiece(board, 5, 0, createPiece('enemy', 1));
+        board = placePiece(board, 0, 1, createPiece('field_marshall', 1));
+
+        for (let i = 0; i < 15; i += 1) {
+            const move = chooseAiMove(board, 0);
+            expect(move).not.toBeNull();
+            if (!move) {
+                return;
+            }
+            const legalDestinations = getSuccessors(
+                board,
+                move.source[0],
+                move.source[1],
+                0,
+            );
+            expect(
+                legalDestinations.some(
+                    ([r, c]) => r === move.target[0] && c === move.target[1],
+                ),
+            ).toBe(true);
+        }
+    });
+
+    test('prefers a clearly winning capture over a losing attack or a quiet move', () => {
+        const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
+        try {
+            let board: Board = emptyBoard();
+            // our piece, free to move onto either neighbor or stay put
+            board = placePiece(board, 5, 2, createPiece('general', 0));
+            // a clearly-losing attack: enemy field marshall outranks us
+            board = placePiece(board, 6, 2, createPiece('field_marshall', 1));
+            // a clean, known-identity capture: engineer is far weaker
+            board = placePiece(board, 4, 2, createPiece('engineer', 1));
+
+            const move = chooseAiMove(board, 0);
+            expect(move).toEqual({ source: [5, 2], target: [4, 2] });
+        } finally {
+            randomSpy.mockRestore();
+        }
+    });
+});

--- a/src/utils/aiPlayer.ts
+++ b/src/utils/aiPlayer.ts
@@ -1,0 +1,142 @@
+import { getSuccessors } from './getSuccessors';
+import { pieces, Piece } from './piece';
+import { Board } from './board';
+
+export type AiMove = { source: [number, number]; target: [number, number] };
+
+// tunable weights for the heuristic move scorer
+const ADVANCE_WEIGHT = 0.15;
+const EXPOSURE_WEIGHT = 0.5;
+const JITTER = 1.5;
+const TOP_MARGIN = 1;
+const CAPTURE_BONUS = 1;
+const WIN_GAME_SCORE = 1000;
+
+// counts of remaining army pieces by rank, derived once from the static
+// piece table (deliberately NOT adjusted for pieces already seen dead -
+// a fogged player never legitimately knows the enemy's own losses either)
+const ORDER_COUNTS: Record<number, number> = {};
+Object.values(pieces).forEach(({ count, order }) => {
+    if (order === -1) {
+        return;
+    }
+    ORDER_COUNTS[order] = (ORDER_COUNTS[order] || 0) + count;
+});
+const BOMB_COUNT = pieces.bomb.count;
+const LANDMINE_COUNT = pieces.landmine.count;
+
+const countInOrderRange = (minOrder: number, maxOrder: number): number => {
+    let total = 0;
+    for (let order = minOrder; order <= maxOrder; order += 1) {
+        total += ORDER_COUNTS[order] || 0;
+    }
+    return total;
+};
+
+// expected value of attacking a still-hidden 'enemy' square, based only on
+// the static prior over what the opponent's remaining army could be
+function estimateHiddenTargetScore(sourceName: string, sourceOrder: number): number {
+    if (sourceName === 'bomb') {
+        // a bomb always mutually destroys whatever it attacks, so this is a
+        // guaranteed trade for a random enemy piece - modestly good odds
+        return 1;
+    }
+
+    const isEngineer = sourceName === 'engineer';
+    const winCount =
+        countInOrderRange(0, sourceOrder - 1) + (isEngineer ? LANDMINE_COUNT : 0);
+    const mutualCount =
+        (ORDER_COUNTS[sourceOrder] || 0) + BOMB_COUNT + (isEngineer ? 0 : LANDMINE_COUNT);
+    const dieCount = countInOrderRange(sourceOrder + 1, 9);
+    const total = winCount + mutualCount + dieCount;
+    if (total === 0) {
+        return 0;
+    }
+
+    const pWin = winCount / total;
+    const pDie = dieCount / total;
+    // winning captures a piece somewhere below our own rank (rough estimate);
+    // dying loses a piece worth our own rank; mutual trades are roughly neutral
+    return pWin * (sourceOrder * 0.6 + CAPTURE_BONUS) - pDie * sourceOrder;
+}
+
+// deterministic outcome of attacking a target whose identity is known
+// (fog off, or a revealed flag) - mirrors pieceMovement's combat rules
+function evaluateKnownTarget(source: Piece, target: Piece): number {
+    if (
+        source.name === 'bomb' ||
+        source.name === target.name ||
+        target.name === 'bomb' ||
+        (source.name !== 'engineer' && target.name === 'landmine')
+    ) {
+        return 0; // mutual destruction, roughly neutral
+    }
+    if (
+        source.order > target.order ||
+        (source.name === 'engineer' && target.name === 'landmine')
+    ) {
+        return target.name === 'flag' ? WIN_GAME_SCORE : target.order + CAPTURE_BONUS;
+    }
+    return -source.order; // source loses
+}
+
+function computeThreatenedSquares(board: Board, aiPlayerIndex: number): Set<string> {
+    const threatened = new Set<string>();
+    for (let r = 0; r < 12; r += 1) {
+        for (let c = 0; c < 5; c += 1) {
+            const piece = board[r][c];
+            if (piece && piece.affiliation !== aiPlayerIndex) {
+                getSuccessors(board, r, c, piece.affiliation).forEach(
+                    ([tr, tc]) => threatened.add(`${tr},${tc}`),
+                );
+            }
+        }
+    }
+    return threatened;
+}
+
+/**
+ * Picks a move for the AI opponent using simple heuristics, respecting fog
+ * of war - it only ever sees `fogBoard`, the same view emplaceBoardFog
+ * would send a real player, never the true identity of enemy pieces.
+ * @see chooseAiMove
+ */
+export function chooseAiMove(fogBoard: Board, aiPlayerIndex: number): AiMove | null {
+    const enemyHQRow = aiPlayerIndex === 0 ? 0 : 11;
+    const threatenedSquares = computeThreatenedSquares(fogBoard, aiPlayerIndex);
+
+    const candidates: { move: AiMove; score: number }[] = [];
+    for (let r = 0; r < 12; r += 1) {
+        for (let c = 0; c < 5; c += 1) {
+            const piece = fogBoard[r][c];
+            if (!piece || piece.affiliation !== aiPlayerIndex) {
+                continue;
+            }
+            const destinations = getSuccessors(fogBoard, r, c, aiPlayerIndex);
+            destinations.forEach(([tr, tc]) => {
+                const target = fogBoard[tr][tc];
+                let score: number;
+                if (target === null) {
+                    score = ADVANCE_WEIGHT * -Math.abs(tr - enemyHQRow);
+                    if (threatenedSquares.has(`${tr},${tc}`)) {
+                        score -= piece.order * EXPOSURE_WEIGHT;
+                    }
+                } else if (target.name === 'enemy') {
+                    score = estimateHiddenTargetScore(piece.name, piece.order);
+                } else {
+                    score = evaluateKnownTarget(piece, target);
+                }
+                score += (Math.random() - 0.5) * JITTER;
+                candidates.push({ move: { source: [r, c], target: [tr, tc] }, score });
+            });
+        }
+    }
+
+    if (candidates.length === 0) {
+        return null;
+    }
+    candidates.sort((a, b) => b.score - a.score);
+    const topScore = candidates[0].score;
+    const topCandidates = candidates.filter((c) => c.score >= topScore - TOP_MARGIN);
+    return topCandidates[Math.floor(Math.random() * topCandidates.length)].move;
+}

--- a/src/utils/aiSetup.test.ts
+++ b/src/utils/aiSetup.test.ts
@@ -1,0 +1,76 @@
+import { generateRandomValidHalfBoard } from './aiSetup';
+import { validateSetup } from './validateSetup';
+import { pieces } from './piece';
+import { Piece } from './piece';
+
+describe('generateRandomValidHalfBoard', () => {
+    test('produces a half-board that passes validateSetup, repeatedly', () => {
+        for (let i = 0; i < 25; i += 1) {
+            const board = generateRandomValidHalfBoard(1);
+            const [isValid, errors] = validateSetup(
+                board as unknown as Piece[][],
+                false,
+            );
+            expect(errors).toEqual([]);
+            expect(isValid).toBe(true);
+        }
+    });
+
+    test('places exactly the expected count of each piece', () => {
+        const board = generateRandomValidHalfBoard(0);
+        const flat = board.flat().filter((p): p is Piece => p !== null);
+        Object.entries(pieces).forEach(([name, { count }]) => {
+            if (name === 'enemy') {
+                return;
+            }
+            expect(flat.filter((p) => p.name === name)).toHaveLength(count);
+        });
+    });
+
+    test('assigns every piece the requested affiliation', () => {
+        const board = generateRandomValidHalfBoard(1);
+        board.flat().forEach((piece) => {
+            if (piece) {
+                expect(piece.affiliation).toBe(1);
+            }
+        });
+    });
+
+    test('keeps bombs off the frontline row (row 5)', () => {
+        for (let i = 0; i < 10; i += 1) {
+            const board = generateRandomValidHalfBoard(0);
+            board[5].forEach((piece) => {
+                expect(piece?.name).not.toBe('bomb');
+            });
+        }
+    });
+
+    // submitInitialBoard (gameplayService.ts) reverses a guest-seat
+    // (playerIndex !== 0) submission exactly once before validating it, so
+    // whatever is actually sent as `myPositions` must be pre-reversed to
+    // cancel that out. Passing the generator's raw output straight through
+    // (the bug this guards against) silently fails validation instead.
+    test('a single reversal (the real submission, unpatched) fails validateSetup', () => {
+        const board = generateRandomValidHalfBoard(1);
+        const unpatchedSubmission = [...board].reverse();
+        const [isValid] = validateSetup(
+            unpatchedSubmission as unknown as Piece[][],
+            false,
+        );
+        expect(isValid).toBe(false);
+    });
+
+    test('submitAiInitialBoard pre-reverses so the real submission round-trips to a valid board', () => {
+        for (let i = 0; i < 25; i += 1) {
+            const board = generateRandomValidHalfBoard(1);
+            // mirrors submitAiInitialBoard's pre-reversal
+            const patchedSubmission = [...board].reverse().reverse();
+            const [isValid, errors] = validateSetup(
+                patchedSubmission as unknown as Piece[][],
+                false,
+            );
+            expect(errors).toEqual([]);
+            expect(isValid).toBe(true);
+        }
+    });
+});

--- a/src/utils/aiSetup.ts
+++ b/src/utils/aiSetup.ts
@@ -1,0 +1,94 @@
+import { createPiece, pieces } from './piece';
+import { isCamp } from './core';
+import { validateSetup } from './validateSetup';
+import { Board } from './board';
+
+const HALF_ROWS = 6;
+const COLS = 5;
+
+type Cell = [number, number];
+
+const sameCell = (a: Cell, b: Cell) => a[0] === b[0] && a[1] === b[1];
+
+function shuffle<T>(items: T[]): T[] {
+    const shuffled = [...items];
+    for (let i = shuffled.length - 1; i > 0; i -= 1) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled;
+}
+
+/**
+ * Builds a random half-board that satisfies validateSetup by construction:
+ * flag in the HQ, landmines in the back two rows, bombs kept off the
+ * frontline row, and the remaining pieces shuffled into the rest. Used to
+ * give the AI opponent a placement without a real player.
+ * @see generateRandomValidHalfBoard
+ */
+export function generateRandomValidHalfBoard(affiliation: number): Board {
+    const allCells: Cell[] = [];
+    for (let r = 0; r < HALF_ROWS; r += 1) {
+        for (let c = 0; c < COLS; c += 1) {
+            if (!isCamp(r, c)) {
+                allCells.push([r, c]);
+            }
+        }
+    }
+    const hqCells = allCells.filter(([r, c]) => r === 0 && (c === 1 || c === 3));
+    // validateSetup flags landmines at r >= 4, so they may only sit at r < 4
+    const landmineEligibleCells = allCells.filter(([r]) => r < 4);
+    // validateSetup flags bombs at r === 5 (the frontline row) only
+    const frontlineCells = allCells.filter(([r]) => r === 5);
+
+    const board: Board = Array.from({ length: HALF_ROWS }, () =>
+        Array(COLS).fill(null),
+    );
+    let remainingCells = allCells;
+
+    const place = (cell: Cell, name: string) => {
+        board[cell[0]][cell[1]] = createPiece(name, affiliation);
+        remainingCells = remainingCells.filter((c) => !sameCell(c, cell));
+    };
+
+    const flagCell = shuffle(hqCells)[0];
+    place(flagCell, 'flag');
+
+    const landmineCells = shuffle(
+        landmineEligibleCells.filter((cell) =>
+            remainingCells.some((c) => sameCell(c, cell)),
+        ),
+    ).slice(0, pieces.landmine.count);
+    landmineCells.forEach((cell) => place(cell, 'landmine'));
+
+    const pool = shuffle(
+        Object.entries(pieces).flatMap(([name, { count }]) =>
+            name === 'flag' || name === 'landmine' || name === 'enemy'
+                ? []
+                : Array(count).fill(name),
+        ),
+    );
+    const bombNames = pool.filter((name) => name === 'bomb');
+    const otherNames = pool.filter((name) => name !== 'bomb');
+
+    const nonFrontlineRemaining = shuffle(
+        remainingCells.filter(
+            (cell) => !frontlineCells.some((c) => sameCell(c, cell)),
+        ),
+    );
+    bombNames.forEach((name, i) => place(nonFrontlineRemaining[i], name));
+
+    const restCells = shuffle(remainingCells);
+    otherNames.forEach((name, i) => place(restCells[i], name));
+
+    const [isValid, errors] = validateSetup(
+        board as unknown as Parameters<typeof validateSetup>[0],
+        false,
+    );
+    if (!isValid) {
+        throw new Error(
+            `Generated AI setup failed validation: ${errors.join(', ')}`,
+        );
+    }
+    return board;
+}

--- a/src/utils/fog.ts
+++ b/src/utils/fog.ts
@@ -1,0 +1,61 @@
+import { cloneDeep } from 'lodash';
+import { createPiece } from './piece';
+import { printBoard } from './board';
+import { Piece } from '../types';
+
+/**
+ * Produces the view of a game that a given player is legitimately allowed
+ * to see: their own pieces as-is, and enemy pieces replaced with a generic
+ * 'enemy' placeholder (unless the enemy's field marshall has died, in which
+ * case their flag is revealed). Also filters dead pieces down to the
+ * player's own, since a fogged player never legitimately learns which of
+ * the opponent's pieces have died.
+ * @see emplaceBoardFog
+ */
+export const emplaceBoardFog = (
+    game: { board: Piece[][]; deadPieces: Piece[] },
+    playerIndex: number,
+) => {
+    // copy the board because we are diverging them
+    const myBoard = cloneDeep(game.board);
+    const enemyHasFieldMarshall = myBoard.some((row: Piece[]) =>
+        row.some((space: Piece | null) => {
+            return (
+                space != null &&
+                space.affiliation !== playerIndex &&
+                space.name === 'field_marshall'
+            );
+        }),
+    );
+
+    const myDeadPieces = game.deadPieces.filter(
+        (piece) => piece.affiliation == playerIndex,
+    );
+
+    myBoard.forEach((row: Piece[], y: number) => {
+        // for each space
+        row.forEach((space: Piece | null, x: number) => {
+            // only replace pieces that are there
+            if (space !== null && space.affiliation !== playerIndex) {
+                // reveal flag if field marshall is captured
+                const isRevealedFlag =
+                    space.name === 'flag' && !enemyHasFieldMarshall;
+
+                // hide piece if is enemy piece and not revealed flag
+                if (!isRevealedFlag) {
+                    myBoard[y][x] = {
+                        0: y,
+                        1: x,
+                        length: 2,
+                        ...createPiece('enemy', 1 - playerIndex), // indicate the affiliation as opposite of oneself
+                    };
+                }
+            }
+        });
+    });
+    const myGame = cloneDeep(game);
+    myGame.board = myBoard;
+    myGame.deadPieces = myDeadPieces;
+    printBoard(myBoard);
+    return myGame;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,3 +3,5 @@ export * from './getSuccessors';
 export * from './piece';
 export * from './board'
 export * from './validateSetup';
+export * from './fog';
+export * from './aiConstants';


### PR DESCRIPTION
Closes #62 

## Summary
- **Reconnection**: every seat gets a per-player token at join time; the client persists it and silently reclaims its seat via a new `playerRejoinRoom` event on reload/reconnect instead of hitting the join form again. Game state was already durable in Mongo - this was purely a "reconnect a socket to its seat" gap.
- **Fixes a latent leak** surfaced by adding the token: every game broadcast/REST response shipped the raw Mongoose document (including internal socket-id/uid maps). Adds `sanitizeGameForClient`, applied everywhere a game is emitted or returned.
- **Single-player vs AI**: new `opponentType: 'ai'` game mode. Luzhanqi is imperfect-information (fog of war hides enemy pieces), so the AI only ever sees the same fogged board a human opponent would - it scores legal moves heuristically (capture value, risk against hidden pieces, positional advancement, exposure) rather than searching the true board. The AI occupies a virtual second seat (no real socket) and auto-places a randomly-generated valid setup.
- Extracts `playerMakeMove`/`playerInitialBoard`'s validation+persistence logic out of the Socket handlers into `src/services/gameplayService.ts` (`applyMove`/`submitInitialBoard`), since both features needed to call them without a real socket (AI turns, rejoin snapshots).

## Test plan
- [x] `npm run build` (tsc) and `npx jest` (10 suites / 182 tests, including new coverage for the AI setup generator, move scorer, and sanitizer)
- [x] Verified live in a real browser end-to-end (Playwright against `docker compose up` + Vite dev server):
  - vs-AI game skips the Lobby, human places pieces, AI auto-places and its pieces render as generic hidden tiles (fog confirmed working)
  - guest reload silently rejoins (player list restored, no join form) instead of losing their seat
- [x] Manual follow-up: full mid-game reconnection (reload during active gameplay, not just the lobby) and a full played-out vs-AI match

🤖 Generated with [Claude Code](https://claude.com/claude-code)