### PR TITLE
feat: include move history in reconnect payload; fix dead-pieces bug

### DIFF
--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -303,6 +303,7 @@ async function playerRejoinRoom(
         turn: myGame.turn,
         board,
         deadPieces,
+        moves: myGame.moves,
         submittedSide: myGame.playersSubmittedSetup?.includes(playerName) ?? false,
         winnerIndex,
         gameStats,

--- a/src/services/gameplayService.test.ts
+++ b/src/services/gameplayService.test.ts
@@ -1,0 +1,52 @@
+import { pieceMovement } from './gameplayService';
+import { emptyBoard } from '../utils/board';
+import { createPiece, placePiece } from '../utils/piece';
+
+describe('pieceMovement', () => {
+    test('a quiet move onto an empty tile does not mark the moving piece dead', () => {
+        let board = emptyBoard();
+        board = placePiece(board, 6, 0, createPiece('engineer', 0));
+
+        const { board: newBoard, deadPieces } = pieceMovement(board, [6, 0], [7, 0]);
+
+        expect(deadPieces).toEqual([]);
+        expect(newBoard[7][0]).toMatchObject({ name: 'engineer', affiliation: 0 });
+        expect(newBoard[6][0]).toBeNull();
+    });
+
+    test('capturing a weaker piece marks only the captured piece dead, not the winner', () => {
+        let board = emptyBoard();
+        board = placePiece(board, 6, 0, createPiece('general', 0));
+        board = placePiece(board, 7, 0, createPiece('captain', 1));
+
+        const { board: newBoard, deadPieces } = pieceMovement(board, [6, 0], [7, 0]);
+
+        expect(deadPieces).toEqual([expect.objectContaining({ name: 'captain', affiliation: 1 })]);
+        expect(newBoard[7][0]).toMatchObject({ name: 'general', affiliation: 0 });
+        expect(newBoard[6][0]).toBeNull();
+    });
+
+    test('attacking a stronger piece marks only the attacker dead', () => {
+        let board = emptyBoard();
+        board = placePiece(board, 6, 0, createPiece('captain', 0));
+        board = placePiece(board, 7, 0, createPiece('general', 1));
+
+        const { board: newBoard, deadPieces } = pieceMovement(board, [6, 0], [7, 0]);
+
+        expect(deadPieces).toEqual([expect.objectContaining({ name: 'captain', affiliation: 0 })]);
+        expect(newBoard[7][0]).toMatchObject({ name: 'general', affiliation: 1 });
+        expect(newBoard[6][0]).toBeNull();
+    });
+
+    test('same-name pieces mutually destroy each other', () => {
+        let board = emptyBoard();
+        board = placePiece(board, 6, 0, createPiece('captain', 0));
+        board = placePiece(board, 7, 0, createPiece('captain', 1));
+
+        const { board: newBoard, deadPieces } = pieceMovement(board, [6, 0], [7, 0]);
+
+        expect(deadPieces).toHaveLength(2);
+        expect(newBoard[7][0]).toBeNull();
+        expect(newBoard[6][0]).toBeNull();
+    });
+});

--- a/src/services/gameplayService.ts
+++ b/src/services/gameplayService.ts
@@ -70,8 +70,10 @@ export function pieceMovement(board: Board, source: Coord, target: Coord) {
         (sourcePiece.name === 'engineer' && targetPiece.name === 'landmine')
     ) {
         // place source piece on target tile, remove source piece from source tile
-        if (sourcePiece) {
-            deadPieces.push(sourcePiece);
+        if (targetPiece) {
+            // a piece was actually captured here - the source piece survives
+            // and occupies the target tile, so it must not be marked dead
+            deadPieces.push(targetPiece);
         }
         board[target[0]][target[1]] = sourcePiece;
         board[source[0]][source[1]] = null;


### PR DESCRIPTION
## Summary
Follow-up to #65 (already merged), pairs with the frontend last-move-highlight PR.

- Adds `moves` to the `youHaveRejoinedTheRoom` snapshot so a reconnecting client can restore the last-move indicator, not just the board/turn.
- Fixes a bug found while testing the highlight feature: `pieceMovement`'s "source wins" branch unconditionally pushed the *moving* piece into `deadPieces`, even for a quiet move onto an empty square where nothing was captured and the piece is still alive on the board. It now only records the piece that was actually captured (`targetPiece`), and only when there was one.

## Test plan
- [x] `npm run build` and `npx jest` (12 suites / 190 tests, including new `pieceMovement` coverage for quiet moves, captures in both directions, and mutual destruction)
- [x] Verified live: a quiet move no longer shows up in the "Dead pieces" tray