### PR TITLE
fix: stale disconnect notice persists after a real reconnect

### DIFF
--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -311,12 +311,22 @@ async function playerRejoinRoom(
     io.sockets.in(gameId).emit('playerReconnected', { playerName });
 }
 
-function playerDisconnect(this: Socket) {
+async function playerDisconnect(this: Socket) {
     const seat = socketSeatRegistry.get(this.id);
     if (!seat) {
         return;
     }
     socketSeatRegistry.delete(this.id);
+
+    // On a page reload, the old socket doesn't always close immediately -
+    // socket.io can take up to the ping-timeout window to notice, so this
+    // disconnect can fire *after* the same player has already reconnected
+    // on a new socket. If a newer socket has since taken over this seat,
+    // this is that stale echo, not a real disconnect - don't announce it.
+    const myGame = await getGameById(seat.gid);
+    if (myGame && myGame.playerToSocketIdMap.get(seat.playerName) !== this.id) {
+        return;
+    }
     io.sockets.in(seat.gid).emit('playerDisconnected', {
         playerName: seat.playerName,
     });


### PR DESCRIPTION
## Summary
Reported bug: the "X disconnected — waiting for them to reconnect…" banner would sometimes stick around even after the player actually reconnected.

Root cause: on a page reload, the old socket doesn't always close immediately - socket.io can take up to the ping-timeout window (~20-45s) to notice a dead connection. So the sequence was often: new socket rejoins → `playerReconnected` clears the banner → the *old* socket's `disconnect` event fires afterward → re-announces `playerDisconnected` with nothing left to clear it.

`playerDisconnect` now checks whether the disconnecting socket is still the one on record (`playerToSocketIdMap`) for that seat before announcing anything. If a newer socket has already taken over (the reload case), it's a stale echo and gets silently dropped.

## Test plan
- [x] `npm run build` and `npx jest` (12 suites / 190 tests, unaffected)
- [x] Verified live: host + guest join a room, guest reloads, waited 25s (past the ping-timeout window) - no disconnect banner appears on the host's page