### PR TITLE
feat(lzqgame): broadcast field marshal deaths to the whole room

### DIFF
--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -658,6 +658,7 @@ async function playerMakeMove(
 
     console.info(`Someone made a move, the turn is now ${result.turn}`);
     await broadcastGameState(io, result.game, 'playerMadeMove');
+    broadcastFieldMarshallDown(gid, result.fieldMarshallDown);
 
     if (result.winnerIndex !== -1) {
         console.info('game ended from victory', result.gameStats);
@@ -671,6 +672,19 @@ async function playerMakeMove(
 
     if (result.game.config.opponentType === 'ai') {
         scheduleAiTurn(gid, result.turn);
+    }
+}
+
+// announces to the whole room (players + spectators) that one or both
+// field marshals died on the move that just resolved - relevant to both
+// sides since the opponent's flag becomes revealed once their field
+// marshal falls (see emplaceBoardFog)
+function broadcastFieldMarshallDown(
+    gid: string,
+    fieldMarshallDown: { playerName: string; affiliation: number }[],
+) {
+    if (fieldMarshallDown.length) {
+        io.sockets.in(gid).emit('fieldMarshallDown', fieldMarshallDown);
     }
 }
 
@@ -732,6 +746,7 @@ async function runAiTurn(gid: string, turn: number) {
     }
 
     await broadcastGameState(io, result.game, 'playerMadeMove');
+    broadcastFieldMarshallDown(gid, result.fieldMarshallDown);
     if (result.winnerIndex !== -1) {
         console.info('game ended from victory (AI)', result.gameStats);
         io.sockets.in(gid).emit('endGame', {

--- a/src/services/gameplayService.ts
+++ b/src/services/gameplayService.ts
@@ -153,6 +153,7 @@ export type MoveResult =
           deadPieces: Piece[];
           winnerIndex: number;
           gameStats: GameStats | null;
+          fieldMarshallDown: { playerName: string; affiliation: number }[];
       }
     | { ok: false; reason: string };
 
@@ -213,10 +214,18 @@ export async function applyMove(
         await updateGame(gid, { winnerId: uid || 'anonymous', phase: 3 });
     }
 
+    const fieldMarshallDown = deadPieces
+        .filter((piece) => piece.name === 'field_marshall')
+        .map((piece) => ({
+            playerName: updatedGame.players[piece.affiliation],
+            affiliation: piece.affiliation,
+        }));
+
     return {
         ok: true,
         game: updatedGame,
         turn: newTurn,
+        fieldMarshallDown,
         deadPieces,
         winnerIndex,
         gameStats,


### PR DESCRIPTION
## Summary
- `applyMove` now reports which side(s), if any, lost their field marshal on the move that just resolved. A field marshal can only die via mutual destruction (attacking/being attacked by a bomb, or the rare case of both field marshals attacking each other directly), so this is derived straight from `pieceMovement`'s `deadPieces`.
- `playerMakeMove` and `runAiTurn` both broadcast a new `fieldMarshallDown` event to the whole room (players + spectators) whenever this happens - notable to both sides since the loser's flag becomes revealed to their opponent once their field marshal falls (see `emplaceBoardFog`).

Pairs with the frontend PR which turns this into a toast notification.

## Test plan
- [x] `npm run build` and `npx jest` (12 suites / 190 tests, unaffected)
- [x] Verified live: seeded a board (via `mongosh`) forcing a bomb-vs-field-marshal trade, made the move through the UI, confirmed `deadPieces` correctly attributes the field marshal to the losing side and the event fires exactly once per death