### PR TITLE
feat(ai): make single-player AI weights configurable per game

### DIFF
--- a/src/controllers/gameController.ts
+++ b/src/controllers/gameController.ts
@@ -1,6 +1,10 @@
 import crypto from 'crypto';
 import Game, { GameConfigData } from '../models/Game';
-import { AI_PLAYER_NAME, AI_SOCKET_SENTINEL } from '../utils/aiConstants';
+import {
+    AI_PLAYER_NAME,
+    AI_SOCKET_SENTINEL,
+    DEFAULT_AI_WEIGHTS,
+} from '../utils/aiConstants';
 
 /**
  * generates an opaque random token used to prove ownership of a player's
@@ -56,6 +60,7 @@ export const createGame = async ({
         fogOfWar: true,
         opponentType: 'human',
         ...gameConfig,
+        aiSettings: { ...DEFAULT_AI_WEIGHTS, ...gameConfig?.aiSettings },
     };
     const game = new Game({
         players: [host],

--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -25,7 +25,7 @@ import {
 } from './services/gameplayService';
 import { getSuccessors, emplaceBoardFog } from './utils';
 import { chooseAiMove } from './utils/aiPlayer';
-import { AI_PLAYER_NAME } from './utils/aiConstants';
+import { AI_PLAYER_NAME, DEFAULT_AI_WEIGHTS } from './utils/aiConstants';
 import { Board, Piece } from './types';
 
 let io: Server;
@@ -718,7 +718,11 @@ async function runAiTurn(gid: string, turn: number) {
               aiPlayerIndex,
           )
         : myGame;
-    const move = chooseAiMove(fogged.board as Board, aiPlayerIndex);
+    const move = chooseAiMove(
+        fogged.board as Board,
+        aiPlayerIndex,
+        myGame.config.aiSettings || DEFAULT_AI_WEIGHTS,
+    );
 
     if (!move) {
         // AI has no legal moves - treat it as a forfeit (a pre-existing gap

--- a/src/models/Game.ts
+++ b/src/models/Game.ts
@@ -1,14 +1,16 @@
 import { Schema, model, Types, Model } from 'mongoose';
+import { AiWeights } from '../utils/aiConstants';
 
 interface IGameConfig extends Document {
     _id: Types.ObjectId;
     fogOfWar: boolean;
     opponentType: 'human' | 'ai';
+    aiSettings?: AiWeights;
 }
 
 export type GameConfigData = Pick<
     IGameConfig,
-    'fogOfWar' | 'opponentType'
+    'fogOfWar' | 'opponentType' | 'aiSettings'
 >;
 
 export interface IGame extends Document {
@@ -75,6 +77,18 @@ const GameSchema = new Schema<IGame, GameModelType>(
         config: new Schema<IGameConfig>({
             fogOfWar: Boolean,
             opponentType: { type: String, default: 'human' },
+            aiSettings: {
+                type: new Schema(
+                    {
+                        randomness: Number,
+                        positionalDrive: Number,
+                        caution: Number,
+                        aggression: Number,
+                    },
+                    { _id: false },
+                ),
+                required: false,
+            },
         }),
     },
     { timestamps: true },

--- a/src/utils/aiConstants.ts
+++ b/src/utils/aiConstants.ts
@@ -2,3 +2,29 @@
 // It occupies players[1] like a real guest, but has no real socket connection.
 export const AI_PLAYER_NAME = 'Computer';
 export const AI_SOCKET_SENTINEL = '__ai__';
+
+/**
+ * Tunable weights for the AI opponent's heuristic move scorer
+ * (src/utils/aiPlayer.ts). Set per-game via config.aiSettings.
+ */
+export type AiWeights = {
+    /** how much random noise is added to each candidate move's score -
+     * higher makes the AI's play less predictable */
+    randomness: number;
+    /** how strongly the AI favors advancing an empty-tile move toward your
+     * HQ over holding position */
+    positionalDrive: number;
+    /** how strongly the AI avoids moving a valuable piece onto a square a
+     * visible (if unidentified) enemy piece could reach next turn */
+    caution: number;
+    /** how much extra value the AI places on capturing pieces (both known
+     * and still-hidden targets) */
+    aggression: number;
+};
+
+export const DEFAULT_AI_WEIGHTS: AiWeights = {
+    randomness: 1.5,
+    positionalDrive: 0.15,
+    caution: 0.5,
+    aggression: 1,
+};

--- a/src/utils/aiPlayer.test.ts
+++ b/src/utils/aiPlayer.test.ts
@@ -53,4 +53,42 @@ describe('chooseAiMove', () => {
             randomSpy.mockRestore();
         }
     });
+
+    test('honors custom weights - caution trades off against positional drive', () => {
+        const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
+        try {
+            let board: Board = emptyBoard();
+            // our piece, free to advance to (6,2) or retreat to (5,1)
+            board = placePiece(board, 5, 2, createPiece('major', 1));
+            // immobile blockers so those are the only two candidate moves
+            board = placePiece(board, 4, 2, createPiece('landmine', 1));
+            board = placePiece(board, 5, 3, createPiece('landmine', 1));
+            // a visible-but-unidentified enemy piece that threatens (6,2)
+            // (its only reachable squares are its own orthogonal neighbors)
+            board = placePiece(board, 7, 2, createPiece('captain', 0));
+
+            const aggressive = chooseAiMove(board, 1, {
+                randomness: 0,
+                positionalDrive: 2,
+                caution: 0,
+                aggression: 0,
+            });
+            expect(aggressive).toEqual({ source: [5, 2], target: [6, 2] });
+
+            const cautious = chooseAiMove(board, 1, {
+                randomness: 0,
+                positionalDrive: 2,
+                caution: 1,
+                aggression: 0,
+            });
+            // row 5 is a railroad, so retreating along it to either (5,1) or
+            // (5,0) scores identically - either is an acceptable "avoided
+            // the threatened square" outcome, unlike the aggressive case
+            expect(cautious).not.toBeNull();
+            expect(cautious?.source).toEqual([5, 2]);
+            expect(cautious?.target).not.toEqual([6, 2]);
+        } finally {
+            randomSpy.mockRestore();
+        }
+    });
 });

--- a/src/utils/aiPlayer.ts
+++ b/src/utils/aiPlayer.ts
@@ -1,15 +1,12 @@
 import { getSuccessors } from './getSuccessors';
 import { pieces, Piece } from './piece';
 import { Board } from './board';
+import { AiWeights, DEFAULT_AI_WEIGHTS } from './aiConstants';
 
 export type AiMove = { source: [number, number]; target: [number, number] };
 
-// tunable weights for the heuristic move scorer
-const ADVANCE_WEIGHT = 0.15;
-const EXPOSURE_WEIGHT = 0.5;
-const JITTER = 1.5;
+// fixed (non-tunable) constants for the heuristic move scorer
 const TOP_MARGIN = 1;
-const CAPTURE_BONUS = 1;
 const WIN_GAME_SCORE = 1000;
 
 // counts of remaining army pieces by rank, derived once from the static
@@ -35,7 +32,11 @@ const countInOrderRange = (minOrder: number, maxOrder: number): number => {
 
 // expected value of attacking a still-hidden 'enemy' square, based only on
 // the static prior over what the opponent's remaining army could be
-function estimateHiddenTargetScore(sourceName: string, sourceOrder: number): number {
+function estimateHiddenTargetScore(
+    sourceName: string,
+    sourceOrder: number,
+    aggression: number,
+): number {
     if (sourceName === 'bomb') {
         // a bomb always mutually destroys whatever it attacks, so this is a
         // guaranteed trade for a random enemy piece - modestly good odds
@@ -57,12 +58,12 @@ function estimateHiddenTargetScore(sourceName: string, sourceOrder: number): num
     const pDie = dieCount / total;
     // winning captures a piece somewhere below our own rank (rough estimate);
     // dying loses a piece worth our own rank; mutual trades are roughly neutral
-    return pWin * (sourceOrder * 0.6 + CAPTURE_BONUS) - pDie * sourceOrder;
+    return pWin * (sourceOrder * 0.6 + aggression) - pDie * sourceOrder;
 }
 
 // deterministic outcome of attacking a target whose identity is known
 // (fog off, or a revealed flag) - mirrors pieceMovement's combat rules
-function evaluateKnownTarget(source: Piece, target: Piece): number {
+function evaluateKnownTarget(source: Piece, target: Piece, aggression: number): number {
     if (
         source.name === 'bomb' ||
         source.name === target.name ||
@@ -75,7 +76,7 @@ function evaluateKnownTarget(source: Piece, target: Piece): number {
         source.order > target.order ||
         (source.name === 'engineer' && target.name === 'landmine')
     ) {
-        return target.name === 'flag' ? WIN_GAME_SCORE : target.order + CAPTURE_BONUS;
+        return target.name === 'flag' ? WIN_GAME_SCORE : target.order + aggression;
     }
     return -source.order; // source loses
 }
@@ -99,9 +100,17 @@ function computeThreatenedSquares(board: Board, aiPlayerIndex: number): Set<stri
  * Picks a move for the AI opponent using simple heuristics, respecting fog
  * of war - it only ever sees `fogBoard`, the same view emplaceBoardFog
  * would send a real player, never the true identity of enemy pieces.
+ *
+ * `weights` lets a game tune how the AI plays (see aiConstants.ts for the
+ * meaning of each setting and their defaults).
  * @see chooseAiMove
  */
-export function chooseAiMove(fogBoard: Board, aiPlayerIndex: number): AiMove | null {
+export function chooseAiMove(
+    fogBoard: Board,
+    aiPlayerIndex: number,
+    weights: AiWeights = DEFAULT_AI_WEIGHTS,
+): AiMove | null {
+    const { randomness, positionalDrive, caution, aggression } = weights;
     const enemyHQRow = aiPlayerIndex === 0 ? 0 : 11;
     const threatenedSquares = computeThreatenedSquares(fogBoard, aiPlayerIndex);
 
@@ -117,16 +126,16 @@ export function chooseAiMove(fogBoard: Board, aiPlayerIndex: number): AiMove | n
                 const target = fogBoard[tr][tc];
                 let score: number;
                 if (target === null) {
-                    score = ADVANCE_WEIGHT * -Math.abs(tr - enemyHQRow);
+                    score = positionalDrive * -Math.abs(tr - enemyHQRow);
                     if (threatenedSquares.has(`${tr},${tc}`)) {
-                        score -= piece.order * EXPOSURE_WEIGHT;
+                        score -= piece.order * caution;
                     }
                 } else if (target.name === 'enemy') {
-                    score = estimateHiddenTargetScore(piece.name, piece.order);
+                    score = estimateHiddenTargetScore(piece.name, piece.order, aggression);
                 } else {
-                    score = evaluateKnownTarget(piece, target);
+                    score = evaluateKnownTarget(piece, target, aggression);
                 }
-                score += (Math.random() - 0.5) * JITTER;
+                score += (Math.random() - 0.5) * randomness;
                 candidates.push({ move: { source: [r, c], target: [tr, tc] }, score });
             });
         }


### PR DESCRIPTION
## Summary
- `chooseAiMove`'s heuristic weights (randomness, positional drive, caution, aggression) were hardcoded module constants. They're now an `AiWeights` object with defaults in `aiConstants.ts`.
- Threaded through `config.aiSettings` on the `Game` document (deep-merged onto the defaults so a partial object from the client doesn't leave fields `undefined`) and passed to `chooseAiMove` in `runAiTurn`.

Pairs with the frontend PR, which exposes these as sliders under an "Advanced" tab on the create-game form that only appears when "Play against the computer" is checked.

## Test plan
- [x] `npm run build` and `npx jest` (12 suites / 192 tests, including a new test confirming custom weights actually change the AI's move choice - caution vs. positional drive trade-off)
- [x] Verified live: created a game with a custom `aggression` value via the real create-game flow, confirmed it round-trips through to the persisted game's `config.aiSettings` unchanged, with the other three settings left at their defaults