### PR TITLE
feat(games): make in-progress games archivable and always resumable

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -67,6 +67,20 @@ export const removeGame = async (uid: string, gameId: string) => {
     console.error('User not found');
 };
 
+// dismisses a game from a user's "rejoin" prompt without touching their
+// games list - it still appears in their full game history
+export const archiveGame = async (uid: string, gameId: string) => {
+    const myUser = await getUser(uid);
+    if (myUser) {
+        if (!myUser.archivedGames.includes(gameId)) {
+            myUser.archivedGames.push(gameId);
+            await myUser.save();
+        }
+        return myUser;
+    }
+    console.error('User not found');
+};
+
 export const getGames = async (uid: string) => {
     const myUser = await getUser(uid);
     if (myUser) {

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -81,6 +81,16 @@ export const archiveGame = async (uid: string, gameId: string) => {
     console.error('User not found');
 };
 
+export const unarchiveGame = async (uid: string, gameId: string) => {
+    const myUser = await getUser(uid);
+    if (myUser) {
+        myUser.archivedGames = myUser.archivedGames.filter((game) => game !== gameId);
+        await myUser.save();
+        return myUser;
+    }
+    console.error('User not found');
+};
+
 export const getGames = async (uid: string) => {
     const myUser = await getUser(uid);
     if (myUser) {

--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -15,7 +15,7 @@ import {
     deleteGame,
     winner,
 } from './controllers/gameController';
-import { addGame, removeGame, getGames } from './controllers/userController';
+import { addGame, removeGame, getUser } from './controllers/userController';
 import {
     applyMove,
     submitInitialBoard,
@@ -345,11 +345,12 @@ type ActiveGameSummary = {
 };
 
 /**
- * Lets a logged-in user discover in-progress games tied to their account
- * (e.g. from a different device that has no localStorage session for
- * them) that are actually worth rejoining: still ongoing, and either
- * against the AI (always available) or an opponent who's currently
- * connected somewhere.
+ * Lets a logged-in user discover an in-progress game tied to their account
+ * worth rejoining (e.g. from a different device that has no localStorage
+ * session for them). A game is durable in Mongo regardless of who's
+ * currently connected, so "worth rejoining" is purely: not ended, and not
+ * dismissed via archiveGame. Only the single most recently updated such
+ * game is returned - older ones are still visible in full game history.
  */
 async function getMyActiveGames(this: Socket, { uid }: { uid: string | null }) {
     if (!uid) {
@@ -357,10 +358,15 @@ async function getMyActiveGames(this: Socket, { uid }: { uid: string | null }) {
         return;
     }
 
-    const gameIds = (await getGames(uid)) || [];
-    const summaries: ActiveGameSummary[] = [];
+    const myUser = await getUser(uid);
+    const gameIds = myUser?.games || [];
+    const archivedGameIds = new Set(myUser?.archivedGames || []);
+    let mostRecent: (ActiveGameSummary & { updatedAt: Date }) | null = null;
 
     for (const gid of gameIds) {
+        if (archivedGameIds.has(gid)) {
+            continue;
+        }
         // eslint-disable-next-line no-await-in-loop
         const myGame = await getGameById(gid);
         if (!myGame || myGame.phase === 3) {
@@ -375,23 +381,14 @@ async function getMyActiveGames(this: Socket, { uid }: { uid: string | null }) {
         const yourIndex = myGame.players.indexOf(yourPlayerName);
         const opponentName = myGame.players[1 - yourIndex] ?? null;
         const isAiGame = myGame.config.opponentType === 'ai';
-        const opponentSocketId = opponentName
-            ? myGame.playerToSocketIdMap.get(opponentName)
-            : undefined;
-        const opponentSeat = opponentSocketId
-            ? socketSeatRegistry.get(opponentSocketId)
-            : undefined;
-        const opponentConnected =
-            !!opponentSeat &&
-            opponentSeat.gid === gid &&
-            opponentSeat.playerName === opponentName;
+        const updatedAt = (myGame as unknown as { updatedAt: Date }).updatedAt;
 
-        if (isAiGame || opponentConnected) {
-            summaries.push({ gameId: gid, yourPlayerName, opponentName, isAiGame });
+        if (!mostRecent || updatedAt > mostRecent.updatedAt) {
+            mostRecent = { gameId: gid, yourPlayerName, opponentName, isAiGame, updatedAt };
         }
     }
 
-    this.emit('myActiveGames', summaries);
+    this.emit('myActiveGames', mostRecent ? [mostRecent] : []);
 }
 
 async function playerDisconnect(this: Socket) {

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -4,6 +4,9 @@ interface IUser extends Document {
     uid: string;
     rank: number;
     games: Array<string>;
+    // games this user has dismissed from their "rejoin" prompt - still
+    // shown in their full game history, just no longer nagging them
+    archivedGames: Array<string>;
 }
 
 const UserSchema = new Schema<IUser>(
@@ -11,6 +14,7 @@ const UserSchema = new Schema<IUser>(
         uid: String,
         rank: Number,
         games: [],
+        archivedGames: { type: [String], default: [] },
     },
     { timestamps: true },
 );

--- a/src/routes/user/index.ts
+++ b/src/routes/user/index.ts
@@ -9,6 +9,7 @@ import {
     addGame,
     removeGame,
     archiveGame,
+    unarchiveGame,
     getGames,
     getRank,
     setRank,
@@ -54,6 +55,14 @@ user.delete('/:userId/games/:gameId', (req, res) => {
 });
 user.post('/:userId/games/:gameId/archive', async (req, res) => {
     const myUser = await archiveGame(req.params.userId, req.params.gameId);
+    if (myUser) {
+        res.status(200).send(myUser);
+    } else {
+        res.status(404).send('User not found');
+    }
+});
+user.delete('/:userId/games/:gameId/archive', async (req, res) => {
+    const myUser = await unarchiveGame(req.params.userId, req.params.gameId);
     if (myUser) {
         res.status(200).send(myUser);
     } else {

--- a/src/routes/user/index.ts
+++ b/src/routes/user/index.ts
@@ -8,6 +8,7 @@ import {
     getUser,
     addGame,
     removeGame,
+    archiveGame,
     getGames,
     getRank,
     setRank,
@@ -50,6 +51,14 @@ user.post('/:userId/games/:gameId', async (req, res) => {
 });
 user.delete('/:userId/games/:gameId', (req, res) => {
     removeGame(req.params.userId, req.params.gameId);
+});
+user.post('/:userId/games/:gameId/archive', async (req, res) => {
+    const myUser = await archiveGame(req.params.userId, req.params.gameId);
+    if (myUser) {
+        res.status(200).send(myUser);
+    } else {
+        res.status(404).send('User not found');
+    }
 });
 user.get('/:userId/games', getGames);
 user.get('/:userId/rank', getRank);


### PR DESCRIPTION
## Summary
- `getMyActiveGames` previously required an opponent to be currently connected (or an AI game) before surfacing a game to rejoin - meaning once both players left, the game vanished from discovery even though the `Game` document itself was never deleted or made unrejoinable (only a pre-game host leave deletes it; mid-game, `playerLeaveRoom` doesn't touch `players`/`playerToTokenMap`/`playerToUidMap` at all).
- Since resumability was always really a database fact, not a connection fact, `getMyActiveGames` now keys purely off `phase !== 3` - no socket/connection tracking involved. It also now returns only the single most recently updated qualifying game (older ones remain visible via the full games list), and excludes any game the user has archived.
- Adds `User.archivedGames` plus an `archiveGame` controller/route (`POST /user/:userId/games/:gameId/archive`) so a user whose opponent abandoned a game can dismiss the rejoin prompt without needing to rejoin (and maybe forfeit) just to make it go away. Archiving doesn't remove the game from the user's history, only from this prompt.

Pairs with the frontend PR, which adds an Archive button to the banner and Rejoin/Archive actions to the profile's game history table.

## Test plan
- [x] `npm run build` and `npx jest` (12 suites / 192 tests, unaffected)
- [x] Verified live: creating two games for the same account surfaces only the most recent one; archiving it falls back to showing the next one; archiving both leaves the list empty - all while neither game's sockets were connected, confirming resumability no longer depends on any live connection