### PR TITLE
feat(games): add short join codes for sharing a game

### DIFF
--- a/src/controllers/gameController.test.ts
+++ b/src/controllers/gameController.test.ts
@@ -1,4 +1,8 @@
-import { sanitizeGameForClient, generateToken } from './gameController';
+import {
+    sanitizeGameForClient,
+    generateToken,
+    generateJoinCode,
+} from './gameController';
 
 describe('generateToken', () => {
     test('produces a non-empty, non-guessable, unique string each call', () => {
@@ -7,6 +11,21 @@ describe('generateToken', () => {
         expect(a).toEqual(expect.any(String));
         expect(a.length).toBeGreaterThanOrEqual(16);
         expect(a).not.toEqual(b);
+    });
+});
+
+describe('generateJoinCode', () => {
+    test('produces a 6-character code using only unambiguous characters', () => {
+        const code = generateJoinCode();
+        expect(code).toHaveLength(6);
+        expect(code).toMatch(/^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{6}$/);
+        // visually-confusable characters must never appear
+        expect(code).not.toMatch(/[0O1IL]/);
+    });
+
+    test('is not deterministic', () => {
+        const codes = new Set(Array.from({ length: 20 }, () => generateJoinCode()));
+        expect(codes.size).toBeGreaterThan(1);
     });
 });
 

--- a/src/controllers/gameController.ts
+++ b/src/controllers/gameController.ts
@@ -13,6 +13,53 @@ import {
  */
 export const generateToken = (): string => crypto.randomBytes(16).toString('hex');
 
+// excludes visually-ambiguous characters (0/O, 1/I/L) so codes are easy to
+// read aloud or retype correctly
+const JOIN_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+const JOIN_CODE_LENGTH = 6;
+const OBJECT_ID_RE = /^[a-f\d]{24}$/i;
+
+/**
+ * generates a short, human-shareable code (e.g. "7K4X2P") for inviting
+ * others to a game, without the collision check `createGame` applies
+ * @see generateJoinCode
+ */
+export const generateJoinCode = (): string => {
+    let code = '';
+    for (let i = 0; i < JOIN_CODE_LENGTH; i++) {
+        code += JOIN_CODE_ALPHABET[crypto.randomInt(JOIN_CODE_ALPHABET.length)];
+    }
+    return code;
+};
+
+/**
+ * generates a join code guaranteed not to collide with an existing game's
+ * @see generateJoinCode
+ */
+const generateUniqueJoinCode = async (): Promise<string> => {
+    let code = generateJoinCode();
+    while (await Game.exists({ joinCode: code })) {
+        code = generateJoinCode();
+    }
+    return code;
+};
+
+/**
+ * resolves either a real game ObjectId or a short join code to the game's
+ * ObjectId string, so callers (join/spectate) can accept either. Returns
+ * null if a join code doesn't match any game.
+ * @see resolveGameId
+ */
+export const resolveGameId = async (
+    idOrCode: string,
+): Promise<string | null> => {
+    if (OBJECT_ID_RE.test(idOrCode)) {
+        return idOrCode;
+    }
+    const game = await Game.findOne({ joinCode: idOrCode.toUpperCase() });
+    return game ? game._id.toString() : null;
+};
+
 /**
  * strips server-internal identity maps (socket ids, uids, reconnection
  * tokens) from a game object before it is sent to any client. Accepts
@@ -62,7 +109,9 @@ export const createGame = async ({
         ...gameConfig,
         aiSettings: { ...DEFAULT_AI_WEIGHTS, ...gameConfig?.aiSettings },
     };
+    const joinCode = await generateUniqueJoinCode();
     const game = new Game({
+        joinCode,
         players: [host],
         playerToUidMap,
         playerToSocketIdMap,

--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -14,6 +14,7 @@ import {
     addAiPlayer,
     deleteGame,
     winner,
+    resolveGameId,
 } from './controllers/gameController';
 import { addGame, removeGame, getUser } from './controllers/userController';
 import {
@@ -112,6 +113,7 @@ async function hostCreateNewGame(
 
         this.emit('newGameCreated', {
             gameId: string_gid,
+            joinCode: finalGame.joinCode,
             mySocketId: this.id,
             players: finalGame.players,
             phase: finalGame.phase,
@@ -172,10 +174,20 @@ async function playerJoinRoom(
         `Player ${data.playerName} attempting to join room: ${data.joinRoomId} with client ID: ${data.clientId} on socket id: ${this.id}`,
     );
 
+    // data.joinRoomId may be either a real game ObjectId or a short join code
+    const resolvedGid = await resolveGameId(data.joinRoomId);
+    if (!resolvedGid) {
+        this.emit('error', [
+            'This game does not exist. Please enter a valid room code.',
+        ]);
+        return;
+    }
+    data.joinRoomId = resolvedGid;
+
     const existingPlayers = await getPlayers(data.joinRoomId);
     if (!existingPlayers) {
         this.emit('error', [
-            'This game does not exist. Please enter a valid room ID.',
+            'This game does not exist. Please enter a valid room code.',
         ]);
     } else if (existingPlayers.length == 2) {
         this.emit('error', ['There are already two players in this game.']);
@@ -223,6 +235,7 @@ async function playerJoinRoom(
             });
             this.emit('youHaveJoinedTheRoom', {
                 ...data,
+                joinCode: myUpdatedGame.joinCode,
                 token: myUpdatedGame.playerToTokenMap.get(data.playerName),
                 phase: myUpdatedGame.phase,
             });
@@ -531,11 +544,21 @@ async function spectateRoom(
         `Spectator ${data.spectatorName} attempting to join room: ${data.joinRoomId} with client ID: ${data.clientId} on socket id: ${this.id}`,
     );
 
+    // data.joinRoomId may be either a real game ObjectId or a short join code
+    const resolvedGid = await resolveGameId(data.joinRoomId);
+    if (!resolvedGid) {
+        this.emit('error', [
+            'This game does not exist. Please enter a valid room code.',
+        ]);
+        return;
+    }
+    data.joinRoomId = resolvedGid;
+
     const existingGame = await getGameById(data.joinRoomId);
 
     if (!existingGame?.players) {
         this.emit('error', [
-            'This game does not exist. Please enter a valid room ID.',
+            'This game does not exist. Please enter a valid room code.',
         ]);
     } else if (existingGame.moves.length) {
         this.emit('error', [
@@ -583,7 +606,10 @@ async function spectateRoom(
             }
             data.spectators = spectators;
             data.players = existingGame.players;
-            this.emit('youAreSpectatingTheRoom');
+            this.emit('youAreSpectatingTheRoom', {
+                gameId: data.joinRoomId,
+                joinCode: myUpdatedGame.joinCode,
+            });
             io.sockets.in(data.joinRoomId).emit('spectatorJoinedRoom', data);
         } else {
             console.error('Could not spectate given game');

--- a/src/models/Game.ts
+++ b/src/models/Game.ts
@@ -15,6 +15,9 @@ export type GameConfigData = Pick<
 
 export interface IGame extends Document {
     room: string;
+    // short human-shareable code (e.g. "7K4X2P") resolving to this game's
+    // real _id, so players don't have to read/type/paste a 24-char ObjectId
+    joinCode: string;
     players: Array<string>;
     playerToSocketIdMap: Map<string, string>;
     playerToUidMap: Map<string, string | null>;
@@ -60,6 +63,7 @@ type GameModelType = Model<IGame, {}, GameDocumentOverrides>;
 const GameSchema = new Schema<IGame, GameModelType>(
     {
         room: String,
+        joinCode: { type: String, unique: true, sparse: true },
         players: [],
         playerToUidMap: Map,
         playerToSocketIdMap: Map,


### PR DESCRIPTION
## Summary
- Every new game now gets a 6-character join code (e.g. `7K4X2P`), generated from an alphabet that excludes visually-ambiguous characters (`0`/`O`, `1`/`I`/`L`), with a DB-checked retry loop to guarantee uniqueness.
- `playerJoinRoom` and `spectateRoom` now resolve `joinRoomId` through a new `resolveGameId` helper that accepts either the short code or the real 24-char ObjectId (regex-detected, case-insensitive for codes) before doing anything else — so all downstream logic (seat tracking, socket room name, reconnection tokens) is untouched and still keys off the real ObjectId.
- `newGameCreated` / `youHaveJoinedTheRoom` / `youAreSpectatingTheRoom` now include the game's `joinCode` (and, for spectating, the resolved real `gameId`, which that event previously didn't send at all — the frontend was relying on stale client-side state to navigate, which would have broken for code-based joins).

## Test plan
- [x] `npm test` — 194 passing (2 new tests covering join-code format/alphabet)
- [x] `tsc --noEmit` clean
- [x] Live-verified via a raw `socket.io-client` script against a local Mongo+server: host creates a game and receives a 6-char code; a guest joins using only that code (uppercase and lowercase); spectating via the code also resolves correctly; joining via the real ObjectId still works unchanged; a bogus code is rejected with a clean error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHNokmAjWcnP6SJXn5ZKWi