### PR TITLE
feat(ai): have the AI opponent pick from curated example boards

### DIFF
--- a/src/services/gameplayService.ts
+++ b/src/services/gameplayService.ts
@@ -12,7 +12,7 @@ import {
     sanitizeGameForClient,
 } from '../controllers/gameController';
 import { pieces, validateSetup, printBoard, emplaceBoardFog } from '../utils';
-import { generateRandomValidHalfBoard } from '../utils/aiSetup';
+import { chooseAiExampleHalfBoard } from '../utils/exampleBoards';
 import { AI_PLAYER_NAME, AI_SOCKET_SENTINEL } from '../utils/aiConstants';
 import { Board } from '../utils/board';
 import { Piece } from '../utils/piece';
@@ -304,17 +304,18 @@ export async function submitInitialBoard(
 }
 
 /**
- * Generates and submits the AI's setup half-board through the same path a
- * real guest player's placement would take. The AI always occupies seat 1.
+ * Picks one of the curated example half-boards at random and submits it
+ * through the same path a real guest player's placement would take. The AI
+ * always occupies seat 1.
  * @see submitAiInitialBoard
  */
 export async function submitAiInitialBoard(gid: string): Promise<SetupResult> {
-    const aiHalfBoard = generateRandomValidHalfBoard(1);
+    const aiHalfBoard = chooseAiExampleHalfBoard(1);
     // submitInitialBoard reverses non-host (playerIndex !== 0) submissions
     // before validating/storing them, since that's what a real guest
     // player's raw submission is expected to look like (see the guest
     // branch below) - pre-reverse here so it round-trips back to the
-    // valid board generateRandomValidHalfBoard actually built.
+    // valid board chooseAiExampleHalfBoard actually built.
     const submissionOrientedBoard = [...aiHalfBoard].reverse();
     return submitInitialBoard(gid, AI_PLAYER_NAME, submissionOrientedBoard);
 }

--- a/src/utils/exampleBoards.test.ts
+++ b/src/utils/exampleBoards.test.ts
@@ -1,0 +1,67 @@
+import {
+    exampleBoards,
+    buildExampleHalfBoard,
+    chooseAiExampleHalfBoard,
+} from './exampleBoards';
+import { validateSetup } from './validateSetup';
+import { pieces, Piece } from './piece';
+
+describe('buildExampleHalfBoard', () => {
+    test('every curated example passes validateSetup', () => {
+        exampleBoards.forEach((_, index) => {
+            const board = buildExampleHalfBoard(index, 0);
+            const [isValid, errors] = validateSetup(
+                board as unknown as Piece[][],
+                false,
+            );
+            expect(errors).toEqual([]);
+            expect(isValid).toBe(true);
+        });
+    });
+
+    test('every curated example places exactly the expected count of each piece', () => {
+        exampleBoards.forEach((_, index) => {
+            const board = buildExampleHalfBoard(index, 0);
+            const flat = board.flat().filter((p): p is Piece => p !== null);
+            Object.entries(pieces).forEach(([name, { count }]) => {
+                if (name === 'enemy') {
+                    return;
+                }
+                expect(flat.filter((p) => p.name === name)).toHaveLength(count);
+            });
+        });
+    });
+
+    test('assigns every piece the requested affiliation', () => {
+        const board = buildExampleHalfBoard(0, 1);
+        board.flat().forEach((piece) => {
+            if (piece) {
+                expect(piece.affiliation).toBe(1);
+            }
+        });
+    });
+
+    test('a single reversal (the real submission, unpatched) fails validateSetup', () => {
+        const board = buildExampleHalfBoard(0, 1);
+        const unpatchedSubmission = [...board].reverse();
+        const [isValid] = validateSetup(
+            unpatchedSubmission as unknown as Piece[][],
+            false,
+        );
+        expect(isValid).toBe(false);
+    });
+});
+
+describe('chooseAiExampleHalfBoard', () => {
+    test('always returns a valid board for one of the curated examples', () => {
+        for (let i = 0; i < 25; i += 1) {
+            const board = chooseAiExampleHalfBoard(1);
+            const [isValid, errors] = validateSetup(
+                board as unknown as Piece[][],
+                false,
+            );
+            expect(errors).toEqual([]);
+            expect(isValid).toBe(true);
+        }
+    });
+});

--- a/src/utils/exampleBoards.ts
+++ b/src/utils/exampleBoards.ts
@@ -1,0 +1,78 @@
+import { createPiece } from './piece';
+import { validateSetup } from './validateSetup';
+import { Board } from './board';
+
+/**
+ * Curated, rule-legal half-board layouts (kept in sync with
+ * luzhanqi-web's src/data/exampleBoards.js). Row 0 is the frontline, row 5
+ * is the HQ row - the orientation a human sees while editing their board.
+ * 'none' marks the five camp cells, which must stay empty.
+ */
+export const exampleBoards: string[][][] = [
+  // Example 1
+  [
+    ['major_general', 'lieutenant', 'colonel', 'engineer', 'major_general'],
+    ['engineer', 'none', 'field_marshall', 'none', 'engineer'],
+    ['colonel', 'lieutenant', 'none', 'bomb', 'major'],
+    ['brigadier_general', 'none', 'brigadier_general', 'none', 'lieutenant'],
+    ['bomb', 'landmine', 'general', 'captain', 'captain'],
+    ['landmine', 'flag', 'major', 'landmine', 'captain'],
+  ],
+  // Example 2 - fortress: strong pieces and landmines massed around a col-3 flag
+  [
+    ['lieutenant', 'captain', 'colonel', 'captain', 'lieutenant'],
+    ['engineer', 'none', 'major_general', 'none', 'engineer'],
+    ['brigadier_general', 'major', 'none', 'captain', 'brigadier_general'],
+    ['colonel', 'none', 'general', 'none', 'engineer'],
+    ['bomb', 'landmine', 'major_general', 'lieutenant', 'bomb'],
+    ['landmine', 'major', 'field_marshall', 'flag', 'landmine'],
+  ],
+  // Example 3 - flanks: defense spread across both sides with a col-1 flag
+  [
+    ['captain', 'lieutenant', 'colonel', 'lieutenant', 'captain'],
+    ['engineer', 'none', 'general', 'none', 'engineer'],
+    ['major', 'brigadier_general', 'none', 'brigadier_general', 'major'],
+    ['engineer', 'none', 'major_general', 'none', 'colonel'],
+    ['landmine', 'captain', 'major_general', 'field_marshall', 'bomb'],
+    ['bomb', 'flag', 'landmine', 'lieutenant', 'landmine'],
+  ],
+];
+
+/**
+ * Converts a curated example (given in the human-facing orientation above)
+ * into a Board for the given affiliation, reversed into the same
+ * HQ-row-first orientation generateRandomValidHalfBoard produces - so
+ * callers (e.g. submitAiInitialBoard) can treat the two interchangeably.
+ * @see buildExampleHalfBoard
+ */
+export function buildExampleHalfBoard(
+    exampleIndex: number,
+    affiliation: number,
+): Board {
+    const layout = exampleBoards[exampleIndex];
+    const reversed = [...layout].reverse();
+    const board: Board = reversed.map((row) =>
+        row.map((name) => (name === 'none' ? null : createPiece(name, affiliation))),
+    );
+
+    const [isValid, errors] = validateSetup(
+        board as unknown as Parameters<typeof validateSetup>[0],
+        false,
+    );
+    if (!isValid) {
+        throw new Error(
+            `Example board ${exampleIndex} failed validation: ${errors.join(', ')}`,
+        );
+    }
+    return board;
+}
+
+/**
+ * Picks one of the curated example half-boards at random - used to give the
+ * AI opponent a sensible (rather than purely shuffled) placement.
+ * @see chooseAiExampleHalfBoard
+ */
+export function chooseAiExampleHalfBoard(affiliation: number): Board {
+    const index = Math.floor(Math.random() * exampleBoards.length);
+    return buildExampleHalfBoard(index, affiliation);
+}


### PR DESCRIPTION
## Summary
- Adds `src/utils/exampleBoards.ts`: three curated, rule-legal half-board formations, kept in sync with luzhanqi-web's `src/data/exampleBoards.js` (same layouts, same human-facing row orientation - row 0 frontline, row 5 HQ).
- `chooseAiExampleHalfBoard` picks one uniformly at random and validates it through the same `validateSetup` path as everything else.
- `submitAiInitialBoard` now calls this instead of `generateRandomValidHalfBoard`. A fully random shuffle doesn't reflect any real strategy (landmines/bombs/flag could end up anywhere legal); these curated layouts at least cluster pieces sensibly (landmines guarding the flag, stronger pieces held back, etc.).
- `generateRandomValidHalfBoard` itself is left in place and still tested - just no longer wired into the AI's setup path, in case it's wanted elsewhere later.

Pairs with luzhanqi-web#136, which lets a human player pick from the same three layouts via a dropdown in Board Setup (previously only "Example 1" existed, hardcoded, human-only).

## Test plan
- [x] `npm test` - 199 passing (5 new: each curated example validates, correct piece counts, correct affiliation, reversal round-trip, `chooseAiExampleHalfBoard` always valid across 25 random picks)
- [x] `tsc --noEmit` clean
- [x] Live-verified end-to-end via the frontend: hosted a vs-AI game, confirmed the AI's opponent seat gets a fully-placed, legal board matching one of the three curated layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHNokmAjWcnP6SJXn5ZKWi