### PR TITLE
fix(fog): reveal the board once the game ends

### DIFF
--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -313,12 +313,17 @@ async function playerRejoinRoom(
     let board = null;
     let deadPieces: unknown[] = [];
     if (boardComplete) {
-        const view = myGame.config.fogOfWar
-            ? emplaceBoardFog(
-                  myGame as unknown as { board: Piece[][]; deadPieces: Piece[] },
-                  playerIndex,
-              )
-            : myGame;
+        // once the game has ended (phase 3), reveal the full board on
+        // rejoin instead of continuing to fog it - matches the live
+        // in-progress endGame broadcast, which already sends the unfogged
+        // finalGame (see broadcastGameState)
+        const view =
+            myGame.config.fogOfWar && myGame.phase !== 3
+                ? emplaceBoardFog(
+                      myGame as unknown as { board: Piece[][]; deadPieces: Piece[] },
+                      playerIndex,
+                  )
+                : myGame;
         board = view.board;
         deadPieces = view.deadPieces;
     }
@@ -896,7 +901,16 @@ async function playerForfeit(
 
     const gameStats = await getGameStats(gid);
     console.info('game ended due to forfeit');
-    io.sockets.in(gid).emit('endGame', { winnerIndex, gameStats });
+    // unfogged, same as the other endGame emits - the client relies on
+    // finalGame to reveal the board once the game is over (see
+    // GameContext.jsx's endGame handler); the board itself is unaffected by
+    // a forfeit, so myGame (fetched before the phase update above) is still
+    // accurate
+    io.sockets.in(gid).emit('endGame', {
+        winnerIndex,
+        gameStats,
+        finalGame: sanitizeGameForClient(myGame),
+    });
 }
 
 /**

--- a/src/services/gameplayService.ts
+++ b/src/services/gameplayService.ts
@@ -416,8 +416,9 @@ export async function submitAiInitialBoard(gid: string): Promise<SetupResult> {
 
 /**
  * Emits a game-state event to every connected player (fogged per-player if
- * the game has fog of war enabled) and spectator (always unfogged), always
- * sanitized to strip internal identity maps. Skips the AI's sentinel seat.
+ * the game has fog of war enabled and the game is still in progress) and
+ * spectator (always unfogged), always sanitized to strip internal identity
+ * maps. Skips the AI's sentinel seat.
  * @see broadcastGameState
  */
 export async function broadcastGameState(
@@ -425,6 +426,10 @@ export async function broadcastGameState(
     myGame: IGame,
     eventName: string,
 ) {
+    // once the game has ended (phase 3), fog no longer serves its purpose of
+    // hiding in-progress strategy - reveal the full board so players can see
+    // what the enemy's pieces actually were
+    const applyFog = myGame.config.fogOfWar && myGame.phase !== 3;
     myGame.playerToSocketIdMap.forEach(
         (socketId: string, instPlayerName: string) => {
             if (socketId === AI_SOCKET_SENTINEL) {
@@ -434,7 +439,7 @@ export async function broadcastGameState(
             io.to(socketId).emit(
                 eventName,
                 sanitizeGameForClient(
-                    myGame.config.fogOfWar
+                    applyFog
                         ? emplaceBoardFog(
                               myGame as unknown as {
                                   board: FoggablePiece[][];


### PR DESCRIPTION
# Description

Fog of war stayed applied past game-over in three places: `playerMadeMove` broadcasts, a reconnecting player's rejoin view, and `forfeit`'s `endGame` emit (which omitted `finalGame` entirely, unlike the other two). All three now reveal the full board once the game reaches phase 3.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

Verified manually via a fog-of-war game against the AI (forfeit → board reveals). No new automated tests: the changed code is socket/DB-coupled, and there's no existing test infra for that layer (see AGENTS.md). Full existing suite (123/123) still passes.
