### PR TITLE
fix(lzqgame): verify caller is the host before hostRoomFull

### DIFF
--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -192,6 +192,16 @@ async function hostPrepareGame(
     gid: string,
     gameConfig: GameConfigData | null,
 ) {
+    // only the host (always players[0] - see createGame) may start the
+    // game or set its rule config; the client-side "Room Full" button is
+    // already host-only UI, but that alone doesn't stop a socket from
+    // emitting this event directly
+    const myGame = await getGameById(gid);
+    const host = myGame?.players[0];
+    if (!host || !verifyOwnsSeat(this, gid, host)) {
+        return;
+    }
+
     const data = {
         mySocketId: this.id,
         roomId: gid,


### PR DESCRIPTION
# Description

`hostPrepareGame` (the `hostRoomFull` event) applied phase/config changes to any `gid` with no check the caller was that game's actual host — any socket, including the guest already in the room, could prematurely start the game or override its rule config. Reuses the `verifyOwnsSeat` mechanism from #79 against `players[0]` (the host).

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

Verified against a live instance with three real `socket.io-client` connections: the guest's own socket and an uninvolved third socket both get rejected attempting `hostRoomFull` on someone else's game, while the real host's own call still succeeds normally. Full test suite (123/123) unaffected — same as #79, this is unauthenticated-caller behavior the existing unit tests don't cover.
