### PR TITLE
perf(gameplay): collapse redundant DB round trips in applyMove

### DIFF
--- a/src/controllers/gameController.ts
+++ b/src/controllers/gameController.ts
@@ -405,16 +405,22 @@ export const removeSpectator = async ({
     console.error('Game not found');
 };
 
-export const getMoveHistory = async (gid: string) => {
-    const myGame = await getGameById(gid);
+// each of these optionally accepts a game document the caller already
+// fetched, skipping the internal getGameById re-fetch - applyMove is a hot
+// path that used to trigger 5+ redundant re-fetches of the same document
+// per move (see gameplayService.ts's applyMove)
+type PreloadedGame = Awaited<ReturnType<typeof getGameById>>;
+
+export const getMoveHistory = async (gid: string, preloadedGame?: PreloadedGame) => {
+    const myGame = preloadedGame ?? (await getGameById(gid));
     if (myGame) {
         return myGame.moves;
     }
     console.error('Game not found');
 };
 
-export const getDeadPieces = async (gid: string) => {
-    const myGame = await getGameById(gid);
+export const getDeadPieces = async (gid: string, preloadedGame?: PreloadedGame) => {
+    const myGame = preloadedGame ?? (await getGameById(gid));
     if (myGame) {
         return myGame.deadPieces;
     }
@@ -427,16 +433,19 @@ export const getDeadPieces = async (gid: string) => {
  * @returns {boolean} indicates whether the player made a move during their turn
  * @see isPlayerTurn
  */
-export const isPlayerTurn = async ({
-    playerName,
-    gid,
-    turn,
-}: {
-    playerName: string;
-    gid: string;
-    turn: number;
-}) => {
-    const myGame = await getGameById(gid);
+export const isPlayerTurn = async (
+    {
+        playerName,
+        gid,
+        turn,
+    }: {
+        playerName: string;
+        gid: string;
+        turn: number;
+    },
+    preloadedGame?: PreloadedGame,
+) => {
+    const myGame = preloadedGame ?? (await getGameById(gid));
     /** assume the first matching game found is the only result, and that it is correct
      * assume that there are only two players, arrange by odd / even
      * */
@@ -448,14 +457,13 @@ export const isPlayerTurn = async ({
     return turn % 2 === playerId;
 };
 
-export const updateBoard = async (gid: string, board: any) => {
-    await updateGame(gid, { $set: { board } });
-};
+export const updateBoard = async (gid: string, board: any) =>
+    updateGame(gid, { $set: { board } });
 
 export const updateGame = async (
     gid: string,
     updateFields: Record<string, unknown>,
-) => await Game.findByIdAndUpdate(gid, updateFields);
+) => Game.findByIdAndUpdate(gid, updateFields, { new: true });
 
 /**
  * Pure win-check for the captureTheFlag rule variant, extracted from
@@ -517,8 +525,8 @@ export function winnerUnderCaptureTheFlag(myBoard: any): number {
     return -1;
 }
 
-export const winner = async (gid: string) => {
-    const myGame = await getGameById(gid);
+export const winner = async (gid: string, preloadedGame?: PreloadedGame) => {
+    const myGame = preloadedGame ?? (await getGameById(gid));
     if (!myGame) {
         return -1;
     }

--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -403,8 +403,8 @@ async function playerRejoinRoom(
     let winnerIndex: number | null = null;
     let gameStats = null;
     if (myGame.phase === 3 && boardComplete) {
-        winnerIndex = await winner(gameId);
-        gameStats = await getGameStats(gameId);
+        winnerIndex = await winner(gameId, myGame);
+        gameStats = await getGameStats(gameId, myGame);
     }
 
     this.emit('youHaveRejoinedTheRoom', {

--- a/src/services/gameplayService.ts
+++ b/src/services/gameplayService.ts
@@ -5,8 +5,6 @@ import {
     getGameById,
     updateBoard,
     updateGame,
-    getMoveHistory,
-    getDeadPieces,
     isPlayerTurn,
     winner,
     sanitizeGameForClient,
@@ -180,9 +178,17 @@ export type GameStats = {
     lost: { name: string; count: number; order: number }[][];
 };
 
+// accepts an optional game document the caller already fetched, skipping
+// the internal getGameById re-fetch (see applyMove, a hot path that used to
+// trigger 5+ redundant re-fetches of the same document per move)
+type PreloadedGame = Awaited<ReturnType<typeof getGameById>>;
+
 // returns per-player remaining/lost piece counts, or null if the game/board isn't found
-export async function getGameStats(gid: string): Promise<GameStats | null> {
-    const myGame = await getGameById(gid);
+export async function getGameStats(
+    gid: string,
+    preloadedGame?: PreloadedGame,
+): Promise<GameStats | null> {
+    const myGame = preloadedGame ?? (await getGameById(gid));
     if (!myGame?.board) {
         console.error('Game or game board not found.');
         return null;
@@ -260,14 +266,19 @@ export async function applyMove(
     turn: number,
     pendingMove: { source: Coord; target: Coord },
 ): Promise<MoveResult> {
-    const isTurn = await isPlayerTurn({ playerName, gid, turn });
-    if (!isTurn) {
-        return { ok: false, reason: 'It is not your turn.' };
-    }
-
+    // fetched once and threaded through every check/write below instead of
+    // each one independently re-fetching the same document - this used to
+    // be 7 DB reads + 2-3 writes per move (isPlayerTurn, this fetch,
+    // getMoveHistory, getDeadPieces, winner, and getGameStats each did
+    // their own getGameById on top of this one)
     const myGame = await getGameById(gid);
     if (!myGame) {
         return { ok: false, reason: 'Game not found.' };
+    }
+
+    const isTurn = await isPlayerTurn({ playerName, gid, turn }, myGame);
+    if (!isTurn) {
+        return { ok: false, reason: 'It is not your turn.' };
     }
 
     const myBoard = myGame.board;
@@ -286,24 +297,24 @@ export async function applyMove(
     }
 
     const newTurn = turn + 1;
-    await updateBoard(gid, newBoard);
     printBoard(newBoard);
 
-    const moveHistory = await getMoveHistory(gid);
-    const deadPieceHistory = await getDeadPieces(gid);
-    await updateGame(gid, {
+    // board, turn, moves, and deadPieces all commit together as one write
+    // (they were two separate writes before); updateGame now returns the
+    // post-write document ({ new: true }), so this doubles as the "read
+    // back the committed state" step the old code did with a third fetch
+    const updatedGame = await updateGame(gid, {
+        board: newBoard,
         turn: newTurn,
-        moves: [...(moveHistory || []), pendingMove],
-        deadPieces: [...(deadPieceHistory || []), ...deadPieces],
+        moves: [...(myGame.moves || []), pendingMove],
+        deadPieces: [...(myGame.deadPieces || []), ...deadPieces],
     });
-
-    const updatedGame = await getGameById(gid);
     if (!updatedGame) {
         return { ok: false, reason: 'Game not found after update.' };
     }
 
-    const winnerIndex = await winner(gid);
-    const gameStats = await getGameStats(gid);
+    const winnerIndex = await winner(gid, updatedGame);
+    const gameStats = await getGameStats(gid, updatedGame);
     if (winnerIndex !== -1) {
         await updateGame(gid, { winnerId: uid || 'anonymous', phase: 3 });
     }


### PR DESCRIPTION
# Description

`applyMove` made 7 DB reads + 2-3 writes per move (measured ~41ms) — several helpers each independently re-fetched the same game document `applyMove` already had in memory. Threads a single fetch through all of them and combines two writes into one. Companion to the `luzhanqi-web` optimistic-update PR — together they close the ~250ms move-send delay.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

No behavior change intended — signature changes are backward compatible (new param is optional, every other call site unaffected, confirmed via grep before making the change). Full suite (123/123) passes; there's no DB test infrastructure in this repo for any of the touched functions, so this was also verified manually against the live stack alongside the frontend change.
