### PR TITLE
fix(lzqgame): don't let a token hiccup block a valid session-token rejoin

### DIFF
--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -340,9 +340,6 @@ async function playerRejoinRoom(
         `Player ${playerName || '(unknown)'} attempting to rejoin room: ${gameId} on socket id: ${this.id}`,
     );
 
-    const uid = await resolveUid(this, idToken);
-    if (uid === TOKEN_INVALID) return;
-
     const myGame = await getGameById(gameId);
     if (!myGame) {
         this.emit('rejoinFailed', { gameId, reason: 'game-not-found' });
@@ -352,7 +349,10 @@ async function playerRejoinRoom(
     // proof of seat ownership is either the token issued to this device at
     // join time, or - for a device that's never seen this game before -
     // a Firebase-verified uid matching the one recorded for a seat when it
-    // joined (never the raw client-asserted uid)
+    // joined (never the raw client-asserted uid). The session-token path is
+    // tried first and doesn't touch idToken at all, so a transient token-
+    // verification hiccup never blocks a rejoin that would have succeeded
+    // via the session token alone.
     let resolvedPlayerName: string | undefined;
     if (
         playerName &&
@@ -361,10 +361,14 @@ async function playerRejoinRoom(
         myGame.playerToTokenMap.get(playerName) === token
     ) {
         resolvedPlayerName = playerName;
-    } else if (uid) {
-        resolvedPlayerName = myGame.players.find(
-            (p) => myGame.playerToUidMap.get(p) === uid,
-        );
+    } else {
+        const uid = await resolveUid(this, idToken);
+        if (uid === TOKEN_INVALID) return;
+        if (uid) {
+            resolvedPlayerName = myGame.players.find(
+                (p) => myGame.playerToUidMap.get(p) === uid,
+            );
+        }
     }
 
     if (!resolvedPlayerName) {


### PR DESCRIPTION
# Description

`playerRejoinRoom` verified `idToken` unconditionally, even though it's only needed for the uid-fallback path — a transient token-verification failure could abort a rejoin that the session token alone would have resolved. Reordered so the session-token path is tried first. Companion to the `luzhanqi-web` reconnect fix, addressing the same "You do not have permission to act as X" report.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

Full suite (123/123) passes. Verified live alongside the companion frontend PR (restarted the backend mid-game, confirmed the client's automatic reconnect + rejoin succeeds and a subsequent move goes through).
