### PR TITLE
fix(fog): guard emplaceBoardFog against a null board

### DIFF
--- a/src/utils/fog.test.ts
+++ b/src/utils/fog.test.ts
@@ -1,0 +1,48 @@
+import { emplaceBoardFog } from './fog';
+import { emptyBoard } from './board';
+import { createPiece, placePiece } from './piece';
+import { Piece } from '../types';
+
+describe('emplaceBoardFog', () => {
+    // a null board (before both setup halves are merged) used to reach
+    // `.some()` and crash the process - see GH issue #83
+    test('does not throw when the board is null, and returns it unchanged', () => {
+        const game = { board: null, deadPieces: [] };
+        expect(() => emplaceBoardFog(game, 0)).not.toThrow();
+        const result = emplaceBoardFog(game, 0);
+        expect(result.board).toBeNull();
+    });
+
+    test('replaces enemy pieces with a generic placeholder', () => {
+        let board = emptyBoard();
+        board = placePiece(board, 0, 0, createPiece('field_marshall', 1));
+        const result = emplaceBoardFog(
+            { board: board as unknown as Piece[][], deadPieces: [] },
+            0,
+        );
+        expect(result.board?.[0][0].name).toBe('enemy');
+    });
+
+    test('leaves the viewer’s own pieces untouched', () => {
+        let board = emptyBoard();
+        board = placePiece(board, 0, 0, createPiece('field_marshall', 0));
+        const result = emplaceBoardFog(
+            { board: board as unknown as Piece[][], deadPieces: [] },
+            0,
+        );
+        expect(result.board?.[0][0].name).toBe('field_marshall');
+    });
+
+    test('filters deadPieces down to only the viewer’s own', () => {
+        const board = emptyBoard();
+        const result = emplaceBoardFog(
+            { board: board as unknown as Piece[][], deadPieces: [
+                createPiece('captain', 0) as unknown as Piece,
+                createPiece('general', 1) as unknown as Piece,
+            ] },
+            0,
+        );
+        expect(result.deadPieces).toHaveLength(1);
+        expect(result.deadPieces[0].affiliation).toBe(0);
+    });
+});

--- a/src/utils/fog.ts
+++ b/src/utils/fog.ts
@@ -13,9 +13,20 @@ import { Piece } from '../types';
  * @see emplaceBoardFog
  */
 export const emplaceBoardFog = (
-    game: { board: Piece[][]; deadPieces: Piece[] },
+    game: { board: Piece[][] | null; deadPieces: Piece[] },
     playerIndex: number,
 ) => {
+    // the board is null before both halves of setup have been merged. Most
+    // callers already guard against this before calling in, but
+    // routes/games/index.ts's GET /:gameId does not - a verified
+    // participant hitting it before setup completes reached `.some()`
+    // below and crashed the process (GH issue #83). Guarding here instead
+    // of only at each call site means the function is safe regardless of
+    // whether a caller remembers to check first.
+    if (!game.board) {
+        return cloneDeep(game);
+    }
+
     // copy the board because we are diverging them
     const myBoard = cloneDeep(game.board);
     const enemyHasFieldMarshall = myBoard.some((row: Piece[]) =>

--- a/src/utils/fog.ts
+++ b/src/utils/fog.ts
@@ -16,13 +16,10 @@ export const emplaceBoardFog = (
     game: { board: Piece[][] | null; deadPieces: Piece[] },
     playerIndex: number,
 ) => {
-    // the board is null before both halves of setup have been merged. Most
-    // callers already guard against this before calling in, but
-    // routes/games/index.ts's GET /:gameId does not - a verified
-    // participant hitting it before setup completes reached `.some()`
-    // below and crashed the process (GH issue #83). Guarding here instead
-    // of only at each call site means the function is safe regardless of
-    // whether a caller remembers to check first.
+    // the board is null before both halves of setup have been merged. 
+    // Guarding here instead of only at each call site means the 
+    // function is safe regardless of whether a caller remembers to 
+    // check first.
     if (!game.board) {
         return cloneDeep(game);
     }


### PR DESCRIPTION
## Summary
Closes #83.

`GET /games/:gameId` (added in #78) calls `emplaceBoardFog` for any verified participant whenever the game has `fogOfWar` on, without checking that the board has actually been merged yet - `board` is `null` during phase 0/1, before both sides submit their setup. Hitting `myBoard.some(...)` with a null board crashes the process, exactly matching the stack trace in #83.

Every other current caller (`playerRejoinRoom`, `runAiTurn`, `broadcastGameState`) already guards with its own board-truthiness check before calling in, but relying on each call site to remember that check is fragile - the very bug this fixes is a case where a caller didn't. Moves the guard inside `emplaceBoardFog` itself instead, so it's safe regardless of caller.

## Test plan
- [x] New `src/utils/fog.test.ts`: confirms a null board doesn't throw and is returned unchanged, plus regression coverage for the existing enemy-piece-replacement and own-dead-pieces-filtering behavior
- [x] `npm test` - 223 passing
- [x] `tsc --noEmit` clean
- [x] Live-verified against the running server: `GET /games/:gameId` during phase 0 (board still null) returns 200 with no board/deadPieces/moves leaked and no server-side error logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHNokmAjWcnP6SJXn5ZKWi