### PR TITLE
fix(logging): stop game-end stats from collapsing to [Object] in logs

### DIFF
--- a/src/lzqgame.test.ts
+++ b/src/lzqgame.test.ts
@@ -1,0 +1,34 @@
+import { formatGameStats } from './lzqgame';
+import { GameStats } from './services/gameplayService';
+
+describe('formatGameStats', () => {
+    // console.log/info's default inspection depth is 2 - gameStats is 3
+    // levels deep (remain/lost -> per-player array -> piece-count object),
+    // so logging it directly collapsed every piece entry to "[Object]"
+    // instead of printing its contents (GH issue #85)
+    test('renders nested piece-count objects instead of collapsing them to [Object]', () => {
+        const gameStats: GameStats = {
+            remain: [
+                [{ name: 'flag', count: 1, order: 0 }],
+                [{ name: 'captain', count: 3, order: 3 }],
+            ],
+            lost: [
+                [{ name: 'bomb', count: 2, order: -1 }],
+                [{ name: 'general', count: 1, order: 8 }],
+            ],
+        };
+
+        const formatted = formatGameStats(gameStats);
+
+        expect(formatted).not.toContain('[Object]');
+        expect(formatted).toContain('flag');
+        expect(formatted).toContain('captain');
+        expect(formatted).toContain('bomb');
+        expect(formatted).toContain('general');
+    });
+
+    test('handles a null gameStats without throwing', () => {
+        expect(() => formatGameStats(null)).not.toThrow();
+        expect(formatGameStats(null)).toBe('null');
+    });
+});

--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -1,3 +1,4 @@
+import { inspect } from 'util';
 import type { Server, Socket } from 'socket.io';
 import Game, { GameConfigData } from './models/Game';
 import {
@@ -23,6 +24,7 @@ import {
     submitAiInitialBoard,
     broadcastGameState,
     getGameStats,
+    GameStats,
 } from './services/gameplayService';
 import { getSuccessors, emplaceBoardFog, verifyIdToken } from './utils';
 import { chooseAiMove } from './utils/aiPlayer';
@@ -39,6 +41,13 @@ let gameSocket: Socket;
 // just by naming them. Reconnection itself is handled by the DB-backed
 // token, not this in-memory registry.
 const socketSeatRegistry = new Map<string, { gid: string; playerName: string }>();
+
+// console.log/info's default inspection depth is 2, so logging gameStats
+// directly (an array of per-player arrays of piece-count objects, 3 levels
+// deep) collapses every piece entry down to the useless placeholder
+// "[Object]" instead of printing its contents (see GH issue #85).
+export const formatGameStats = (gameStats: GameStats | null) =>
+    inspect(gameStats, { depth: null });
 
 export const initGame = (sio: Server, socket: Socket) => {
     io = sio;
@@ -880,7 +889,7 @@ async function playerMakeMove(
     broadcastFieldMarshallDown(gid, result.fieldMarshallDown);
 
     if (result.winnerIndex !== -1) {
-        console.info('game ended from victory', result.gameStats);
+        console.info('game ended from victory', formatGameStats(result.gameStats));
         io.sockets.in(gid).emit('endGame', {
             winnerIndex: result.winnerIndex,
             gameStats: result.gameStats,
@@ -975,7 +984,7 @@ async function runAiTurn(gid: string, turn: number) {
     await broadcastGameState(io, result.game, 'playerMadeMove');
     broadcastFieldMarshallDown(gid, result.fieldMarshallDown);
     if (result.winnerIndex !== -1) {
-        console.info('game ended from victory (AI)', result.gameStats);
+        console.info('game ended from victory (AI)', formatGameStats(result.gameStats));
         io.sockets.in(gid).emit('endGame', {
             winnerIndex: result.winnerIndex,
             gameStats: result.gameStats,


### PR DESCRIPTION
## Summary
Closes #85.

Not actually a deserialization bug - `console.log`/`console.info`'s default inspection depth is `2`, and `gameStats` (`{ remain, lost }`, each an array of 2 per-player arrays of piece-count objects) is 3 levels deep. Logging it directly collapsed every piece entry down to the placeholder `[Object]` instead of printing its contents - a pure display artifact of Node's default `util.inspect` depth, not lost or corrupted data.

Adds `formatGameStats`, a thin wrapper around `util.inspect(gameStats, { depth: null })`, used at both game-end logging call sites (`playerMakeMove`'s human win and `runAiTurn`'s AI win).

## Test plan
- [x] New `src/lzqgame.test.ts`: confirms `formatGameStats` renders actual piece names (`flag`, `captain`, `bomb`, `general`) instead of `[Object]`, and handles `null` safely
- [x] `npm test` - 256 passing (2 new)
- [x] `tsc --noEmit` / `npm run build` clean
- [x] Live-verified the dev server hot-reloads this file cleanly with no errors