### PR TITLE
fix(board): stop printBoard crashing on a partial setup-phase board

### DIFF
--- a/src/utils/board.test.ts
+++ b/src/utils/board.test.ts
@@ -1,0 +1,15 @@
+import { printBoard, emptyBoard, Board } from './board';
+
+describe('printBoard', () => {
+    test('handles a full 12-row board without throwing', () => {
+        expect(() => printBoard(emptyBoard())).not.toThrow();
+    });
+
+    // a setup-phase board is only 6 rows until both players have submitted
+    // their half (see gameplayService.submitInitialBoard) - printBoard used
+    // to assume a full 12x5 grid and crashed reading row 6 of a 6-row board
+    test('handles a partial 6-row board without throwing', () => {
+        const halfBoard: Board = emptyBoard().slice(0, 6);
+        expect(() => printBoard(halfBoard)).not.toThrow();
+    });
+});

--- a/src/utils/board.ts
+++ b/src/utils/board.ts
@@ -18,30 +18,24 @@ export const emptyBoard = (): Board => {
     return board;
 };
 
-// function that prints the board in a readable format
+// function that prints the board in a readable format. Iterates the
+// board's actual dimensions rather than assuming a full 12x5 grid, since
+// a half-submitted setup board (see gameplayService.submitInitialBoard)
+// only has 6 rows until both players have placed their pieces.
 export const printBoard = (board: Board): void => {
-    for (let i = 0; i < 12; i++) {
+    board.forEach((boardRow, i) => {
         let row = '';
         // after the sixth row, add the frontier
         if (i === 6) {
             row += ' .... [/\\/\\] .... [/\\/\\] .... \n';
         }
-        for (let j = 0; j < 5; j++) {
+        boardRow.forEach((piece, j) => {
+            // first four letters of the piece name, capitalized, or '....' if null
+            const label = piece?.name.slice(0, 4).toUpperCase() || '----';
             // if the row is a camp, surround piece name with brackets
             // otherwise, add a space on either side
-            if (isCamp(i, j)) {
-                // first four letters of the piece name, capitalized, or '....' if null
-                row +=
-                    '[' +
-                    (board[i][j]?.name.slice(0, 4).toUpperCase() || '----') +
-                    ']';
-            } else {
-                row +=
-                    ' ' +
-                    (board[i][j]?.name.slice(0, 4).toUpperCase() || '----') +
-                    ' ';
-            }
-        }
+            row += isCamp(i, j) ? `[${label}]` : ` ${label} `;
+        });
         console.info(row);
-    }
+    });
 };


### PR DESCRIPTION
## Summary
- `printBoard` hardcoded a 12-row x 5-col loop, assuming a full board
- During setup, before both players submit their half, `board` is a 6-row array (see `gameplayService.submitInitialBoard`) - `emplaceBoardFog`'s null guard from #84 didn't cover this partial-but-non-null case
- Hit live via the REST `GET /games/:gameId` route fogging an in-progress setup for a participant, crashing with `TypeError: Cannot read properties of undefined (reading '0')` reading row 6 of a 6-row board
- `printBoard` now iterates the board's actual dimensions instead of assuming 12x5

## Test plan
- [x] New `board.test.ts`: full 12-row board and partial 6-row board both print without throwing
- [x] `tsc --noEmit` clean
- [x] Full suite passes (131 backend tests)
- [x] Reproduced live against the running `docker compose` dev container (tsx watch picked up the fix on save, restarted cleanly)