### PR TITLE
fix(game): count winner()'s flags by affiliation, not scan position

### DIFF
--- a/src/controllers/gameController.test.ts
+++ b/src/controllers/gameController.test.ts
@@ -2,6 +2,7 @@ import {
     sanitizeGameForClient,
     generateToken,
     generateJoinCode,
+    winner,
     winnerUnderCaptureTheFlag,
 } from './gameController';
 import { pieceMovement } from '../services/gameplayService';
@@ -161,5 +162,47 @@ describe('winnerUnderCaptureTheFlag', () => {
         });
 
         expect(winnerUnderCaptureTheFlag(newBoard)).toBe(-1);
+    });
+});
+
+describe('winner (default, non-captureTheFlag rules)', () => {
+    // host (affiliation 0) occupies the bottom half of the merged board
+    // (HQ at row 11); the guest (affiliation 1) occupies the top half
+    // (HQ at row 0) - see submitInitialBoard's merge order. A flag can
+    // legally sit on any row of its owner's half, not just the row
+    // nearest that half's own edge of the board - these boards place
+    // filler pieces in the rows ahead of each flag so a scan actually
+    // encounters other pieces first, the same as a real, mostly-full
+    // game board would.
+    const asPreloadedGame = (board: unknown) => ({ board, config: {} } as any);
+
+    test('no winner while both flags are present, several rows deep in their own half', async () => {
+        let board = emptyBoard();
+        board = placePiece(board, 0, 0, createPiece('captain', 1));
+        board = placePiece(board, 1, 0, createPiece('captain', 1));
+        board = placePiece(board, 3, 3, createPiece('flag', 1));
+        board = placePiece(board, 6, 0, createPiece('captain', 0));
+        board = placePiece(board, 7, 0, createPiece('captain', 0));
+        board = placePiece(board, 8, 1, createPiece('flag', 0));
+
+        expect(await winner('unused', asPreloadedGame(board))).toBe(-1);
+    });
+
+    test('host wins when only the guest half is missing its flag', async () => {
+        let board = emptyBoard();
+        board = placePiece(board, 0, 0, createPiece('captain', 1));
+        board = placePiece(board, 1, 0, createPiece('captain', 1));
+        board = placePiece(board, 8, 1, createPiece('flag', 0));
+
+        expect(await winner('unused', asPreloadedGame(board))).toBe(0);
+    });
+
+    test('guest wins when only the host half is missing its flag', async () => {
+        let board = emptyBoard();
+        board = placePiece(board, 3, 3, createPiece('flag', 1));
+        board = placePiece(board, 6, 0, createPiece('captain', 0));
+        board = placePiece(board, 7, 0, createPiece('captain', 0));
+
+        expect(await winner('unused', asPreloadedGame(board))).toBe(1);
     });
 });

--- a/src/controllers/gameController.ts
+++ b/src/controllers/gameController.ts
@@ -536,26 +536,22 @@ export const winner = async (gid: string, preloadedGame?: PreloadedGame) => {
         return winnerUnderCaptureTheFlag(myBoard);
     }
 
-    let flags = 0;
-    for (let rowI = 0; rowI < myBoard.length; rowI += 1) {
-        const row = myBoard[rowI];
-        for (let colI = 0; colI < row.length; colI += 1) {
-            const piece = row[colI];
-            if (piece === null) {
-                // eslint-disable-next-line no-continue
-                continue;
-            }
-            if (piece.name === 'flag') {
-                flags += 1;
-            }
-            if (rowI > 0 && flags < 1) {
-                // top half loses (host won)
-                console.info('top half loses');
-                return 0;
+    // a flag can legally sit on any row of its owner's half, so this counts
+    // by the piece's own affiliation rather than by scan position
+    const flagsPresent = [false, false];
+    for (const row of myBoard) {
+        for (const piece of row) {
+            if (piece?.name === 'flag') {
+                flagsPresent[piece.affiliation] = true;
             }
         }
     }
-    if (flags < 2) {
+    if (!flagsPresent[1]) {
+        // top half loses (host won)
+        console.info('top half loses');
+        return 0;
+    }
+    if (!flagsPresent[0]) {
         // bottom half loses (guest won)
         console.info('bottom half loses');
         return 1;


### PR DESCRIPTION
## Summary
- Fixes #91: the default (non-`captureTheFlag`) `winner()` path scanned the board row-major and returned a winner as soon as it passed row 0 without having counted a flag yet - since a flag can legally sit on any row of its owner's half (not just the row nearest that half's edge), this misfired whenever the scan reached another piece before reaching the flag's actual row, declaring a winner even though both flags were still on the board.
- Rewrites the count to tally by each piece's own `affiliation` field instead of scan position, matching the same approach `winnerUnderCaptureTheFlag` (right above it in this file) already uses.

## Test plan
- [x] Added a `winner (default, non-captureTheFlag rules)` describe block in `gameController.test.ts` covering: both flags present deep in their own half (the false-positive case), host-wins, and guest-wins
- [x] Verified the primary regression test fails against the pre-fix code with exactly the described false positive (`Expected: -1, Received: 0`) and passes against the fix
- [x] `npm test` - all 134 tests pass
- [x] `tsc-files --noEmit` via pre-commit hook - no type errors