### PR TITLE
docs: rewrite comments that narrated bug/issue history as current facts

### DIFF
--- a/src/controllers/gameController.ts
+++ b/src/controllers/gameController.ts
@@ -407,8 +407,8 @@ export const removeSpectator = async ({
 
 // each of these optionally accepts a game document the caller already
 // fetched, skipping the internal getGameById re-fetch - applyMove is a hot
-// path that used to trigger 5+ redundant re-fetches of the same document
-// per move (see gameplayService.ts's applyMove)
+// path where every independent re-fetch of the same document adds real DB
+// round-trip cost (see gameplayService.ts's applyMove)
 type PreloadedGame = Awaited<ReturnType<typeof getGameById>>;
 
 export const getMoveHistory = async (gid: string, preloadedGame?: PreloadedGame) => {

--- a/src/lzqgame.test.ts
+++ b/src/lzqgame.test.ts
@@ -3,9 +3,8 @@ import { GameStats } from './services/gameplayService';
 
 describe('formatGameStats', () => {
     // console.log/info's default inspection depth is 2 - gameStats is 3
-    // levels deep (remain/lost -> per-player array -> piece-count object),
-    // so logging it directly collapsed every piece entry to "[Object]"
-    // instead of printing its contents (GH issue #85)
+    // levels deep (remain/lost -> per-player array -> piece-count object) -
+    // so formatGameStats must use depth: null to print every level in full
     test('renders nested piece-count objects instead of collapsing them to [Object]', () => {
         const gameStats: GameStats = {
             remain: [

--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -42,10 +42,9 @@ let gameSocket: Socket;
 // token, not this in-memory registry.
 const socketSeatRegistry = new Map<string, { gid: string; playerName: string }>();
 
-// console.log/info's default inspection depth is 2, so logging gameStats
-// directly (an array of per-player arrays of piece-count objects, 3 levels
-// deep) collapses every piece entry down to the useless placeholder
-// "[Object]" instead of printing its contents (see GH issue #85).
+// console.log/info's default inspection depth is 2, but gameStats is an
+// array of per-player arrays of piece-count objects - 3 levels deep - so
+// this needs depth: null to print every level in full.
 export const formatGameStats = (gameStats: GameStats | null) =>
     inspect(gameStats, { depth: null });
 

--- a/src/services/gameplayService.ts
+++ b/src/services/gameplayService.ts
@@ -179,8 +179,8 @@ export type GameStats = {
 };
 
 // accepts an optional game document the caller already fetched, skipping
-// the internal getGameById re-fetch (see applyMove, a hot path that used to
-// trigger 5+ redundant re-fetches of the same document per move)
+// the internal getGameById re-fetch (see applyMove, a hot path where every
+// independent re-fetch of the same document adds real DB round-trip cost)
 type PreloadedGame = Awaited<ReturnType<typeof getGameById>>;
 
 // returns per-player remaining/lost piece counts, or null if the game/board isn't found
@@ -266,11 +266,10 @@ export async function applyMove(
     turn: number,
     pendingMove: { source: Coord; target: Coord },
 ): Promise<MoveResult> {
-    // fetched once and threaded through every check/write below instead of
-    // each one independently re-fetching the same document - this used to
-    // be 7 DB reads + 2-3 writes per move (isPlayerTurn, this fetch,
-    // getMoveHistory, getDeadPieces, winner, and getGameStats each did
-    // their own getGameById on top of this one)
+    // fetched once here and threaded through every check/write below -
+    // isPlayerTurn, getMoveHistory, getDeadPieces, winner, and
+    // getGameStats all take this same document, so a single move costs
+    // one read here plus the writes below
     const myGame = await getGameById(gid);
     if (!myGame) {
         return { ok: false, reason: 'Game not found.' };
@@ -299,10 +298,9 @@ export async function applyMove(
     const newTurn = turn + 1;
     printBoard(newBoard);
 
-    // board, turn, moves, and deadPieces all commit together as one write
-    // (they were two separate writes before); updateGame now returns the
-    // post-write document ({ new: true }), so this doubles as the "read
-    // back the committed state" step the old code did with a third fetch
+    // board, turn, moves, and deadPieces all commit together as one write;
+    // updateGame returns the post-write document ({ new: true }), so this
+    // also serves as the read-back of the committed state
     const updatedGame = await updateGame(gid, {
         board: newBoard,
         turn: newTurn,

--- a/src/utils/fog.test.ts
+++ b/src/utils/fog.test.ts
@@ -4,8 +4,8 @@ import { createPiece, placePiece } from './piece';
 import { Piece } from '../types';
 
 describe('emplaceBoardFog', () => {
-    // a null board (before both setup halves are merged) used to reach
-    // `.some()` and crash the process - see GH issue #83
+    // the board is null before both setup halves are merged, and
+    // emplaceBoardFog must handle that without throwing
     test('does not throw when the board is null, and returns it unchanged', () => {
         const game = { board: null, deadPieces: [] };
         expect(() => emplaceBoardFog(game, 0)).not.toThrow();


### PR DESCRIPTION
Several comments referenced closed GitHub issues or described old code. Removed them.