### PR TITLE
fix(game): bounds-check pieceMovement's coordinates instead of crashing

### DIFF
--- a/src/services/gameplayService.test.ts
+++ b/src/services/gameplayService.test.ts
@@ -321,4 +321,17 @@ describe('pieceMovement', () => {
             expect(newBoard[0][1]?.carryingFlag).toBeUndefined();
         });
     });
+
+    test('an out-of-range coordinate is a no-op, not a thrown error', () => {
+        let board = emptyBoard();
+        board = placePiece(board, 6, 0, createPiece('engineer', 0));
+
+        expect(() => pieceMovement(board, [6, 0], [12, 0])).not.toThrow();
+        expect(() => pieceMovement(board, [-1, 0], [6, 0])).not.toThrow();
+        expect(() => pieceMovement(board, [6, 0], [6, 5])).not.toThrow();
+
+        const { board: newBoard, deadPieces } = pieceMovement(board, [6, 0], [12, 0]);
+        expect(newBoard).toEqual(board);
+        expect(deadPieces).toEqual([]);
+    });
 });

--- a/src/services/gameplayService.ts
+++ b/src/services/gameplayService.ts
@@ -9,7 +9,14 @@ import {
     winner,
     sanitizeGameForClient,
 } from '../controllers/gameController';
-import { pieces, validateSetup, printBoard, emplaceBoardFog } from '../utils';
+import {
+    pieces,
+    validateSetup,
+    printBoard,
+    emplaceBoardFog,
+    isValidRow,
+    isValidCol,
+} from '../utils';
 import { chooseAiExampleHalfBoard } from '../utils/exampleBoards';
 import { AI_PLAYER_NAME, AI_SOCKET_SENTINEL } from '../utils/aiConstants';
 import { Board } from '../utils/board';
@@ -70,6 +77,18 @@ export function pieceMovement(
     const deadPieces: Piece[] = [];
 
     if (!source.length || !target.length) {
+        return { board, deadPieces };
+    }
+
+    // an out-of-range coordinate has no tile to read - every caller of
+    // pieceMovement (a real move, the AI, a test) works with in-bounds
+    // coordinates already, so this only guards a malformed payload
+    if (
+        !isValidRow(source[0]) ||
+        !isValidCol(source[1]) ||
+        !isValidRow(target[0]) ||
+        !isValidCol(target[1])
+    ) {
         return { board, deadPieces };
     }
 


### PR DESCRIPTION
## Summary
- `pieceMovement` indexed `board[source[0]][source[1]]` without checking that the coordinates were in range, so an out-of-range move (e.g. from a client race during board setup) crashed the process with an unhandled `TypeError` instead of being rejected.
- Adds an `isValidRow`/`isValidCol` bounds-check alongside the existing empty-coordinate no-op guard, so an out-of-range move is now a no-op rather than a crash.

## Test plan
- [x] Added a regression test asserting out-of-range source/target coordinates no longer throw and leave the board unchanged
- [x] Full suite passes (135 tests)