### PR TITLE
chore(deps): upgrade firebase-admin to v14.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "debug": "~2.6.9",
                 "dotenv": "^17.4.2",
                 "express": "^4.16.4",
-                "firebase-admin": "^11.4.1",
+                "firebase-admin": "^14.2.0",
                 "lodash": "^4.17.21",
                 "lodash.isequal": "^4.5.0",
                 "mongodb": "^3.6.3",
@@ -261,7 +261,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
             "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -271,7 +271,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
             "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -390,7 +390,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
             "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.29.7"
@@ -682,7 +682,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
             "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.29.7",
@@ -1193,115 +1193,136 @@
             "dev": true
         },
         "node_modules/@fastify/busboy": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-1.2.1.tgz",
-            "integrity": "sha512-7PQA7EH43S0CxcOa9OeAnaeA0oQ+e/DHNPZwSQM9CQHW76jle5+OvLdibRp/Aafs9KXbLhxyjOTkRjWUbQEd3Q==",
-            "license": "MIT",
-            "dependencies": {
-                "text-decoding": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+            "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+            "license": "MIT"
         },
-        "node_modules/@firebase/app-types": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
-            "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q==",
+        "node_modules/@firebase/app-check-interop-types": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+            "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
             "license": "Apache-2.0"
         },
+        "node_modules/@firebase/app-types": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+            "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/logger": "0.5.1"
+            }
+        },
         "node_modules/@firebase/auth-interop-types": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.1.tgz",
-            "integrity": "sha512-VOaGzKp65MY6P5FI84TfYKBXEPi6LmOCSMMzys6o2BN2LOsqy7pCuZCup7NYnfbk5OkkQKzvIfHOzTm0UDpkyg==",
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+            "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
             "license": "Apache-2.0"
         },
         "node_modules/@firebase/component": {
-            "version": "0.6.4",
-            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.4.tgz",
-            "integrity": "sha512-rLMyrXuO9jcAUCaQXCMjCMUsWrba5fzHlNK24xz5j2W6A/SRmK8mZJ/hn7V0fViLbxC0lPMtrK1eYzk6Fg03jA==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+            "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/util": "1.9.3",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@firebase/database": {
-            "version": "0.14.4",
-            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.14.4.tgz",
-            "integrity": "sha512-+Ea/IKGwh42jwdjCyzTmeZeLM3oy1h0mFPsTy6OqCWzcu/KFqRAr5Tt1HRCOBlNOdbh84JPZC47WLU18n2VbxQ==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+            "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/auth-interop-types": "0.2.1",
-                "@firebase/component": "0.6.4",
-                "@firebase/logger": "0.4.0",
-                "@firebase/util": "1.9.3",
+                "@firebase/app-check-interop-types": "0.3.4",
+                "@firebase/auth-interop-types": "0.2.5",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "faye-websocket": "0.11.4",
                 "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@firebase/database-compat": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.3.4.tgz",
-            "integrity": "sha512-kuAW+l+sLMUKBThnvxvUZ+Q1ZrF/vFJ58iUY9kAcbX48U03nVzIF6Tmkf0p3WVQwMqiXguSgtOPIB6ZCeF+5Gg==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+            "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.6.4",
-                "@firebase/database": "0.14.4",
-                "@firebase/database-types": "0.10.4",
-                "@firebase/logger": "0.4.0",
-                "@firebase/util": "1.9.3",
+                "@firebase/component": "0.7.3",
+                "@firebase/database": "1.1.3",
+                "@firebase/database-types": "1.0.20",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@firebase/database-types": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.10.4.tgz",
-            "integrity": "sha512-dPySn0vJ/89ZeBac70T+2tWWPiJXWbmRygYv0smT5TfE3hDrQ09eKMF3Y+vMlTdrMWq7mUdYW5REWPSGH4kAZQ==",
+            "version": "1.0.20",
+            "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+            "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/app-types": "0.9.0",
-                "@firebase/util": "1.9.3"
+                "@firebase/app-types": "0.9.5",
+                "@firebase/util": "1.15.1"
             }
         },
         "node_modules/@firebase/logger": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.0.tgz",
-            "integrity": "sha512-eRKSeykumZ5+cJPdxxJRgAC3G5NknY2GwEbKfymdnXtnT0Ucm4pspfR6GT4MUQEDuJwRVbVcSx85kgJulMoFFA==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+            "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@firebase/util": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.3.tgz",
-            "integrity": "sha512-DY02CRhOZwpzO36fHpuVysz6JZrscPiBXD0fXp6qSrL9oNOx5KWICKdR95C0lSITzxp0TZosVyHqzatE8JbcjA==",
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+            "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+            "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@google-cloud/firestore": {
-            "version": "6.8.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-6.8.0.tgz",
-            "integrity": "sha512-JRpk06SmZXLGz0pNx1x7yU3YhkUXheKgH5hbDZ4kMsdhtfV5qPLJLRI4wv69K0cZorIk+zTMOwptue7hizo0eA==",
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-8.6.0.tgz",
+            "integrity": "sha512-TdvZHfwQj5B5CSDEgDqyrhdVqtOSupmBXDQPasMAJiC64tjsGvyMooNiC43fdk1TsUHeklyoZ6/vQ1TjWKVMbg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "fast-deep-equal": "^3.1.1",
+                "@opentelemetry/api": "^1.9.0",
+                "fast-deep-equal": "^3.1.3",
                 "functional-red-black-tree": "^1.0.1",
-                "google-gax": "^3.5.7",
-                "protobufjs": "^7.2.5"
+                "google-gax": "^5.0.1",
+                "protobufjs": "^7.5.3"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@google-cloud/paginator": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.7.tgz",
-            "integrity": "sha512-jJNutk0arIQhmpUUQJPJErsojqo834KcyB6X7a1mxuic8i1tKXxde8E69IZxNZawRIlZdIK2QY4WALvlK5MzYQ==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+            "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
@@ -1309,57 +1330,155 @@
                 "extend": "^3.0.2"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@google-cloud/projectify": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-3.0.0.tgz",
-            "integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+            "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
             "license": "Apache-2.0",
             "optional": true,
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@google-cloud/promisify": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-3.0.1.tgz",
-            "integrity": "sha512-z1CjRjtQyBOYL+5Qr9DdYIfrdLBe746jRTYfaYU6MeXkqp7UfYs/jX16lFFVzZ7PGEJvqZNqYUEtb1mvDww4pA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+            "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
             "license": "Apache-2.0",
             "optional": true,
             "engines": {
-                "node": ">=12"
+                "node": ">=14"
             }
         },
         "node_modules/@google-cloud/storage": {
-            "version": "6.12.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.12.0.tgz",
-            "integrity": "sha512-78nNAY7iiZ4O/BouWMWTD/oSF2YtYgYB3GZirn0To6eBOugjXVoK+GXgUXOl+HlqbAOyHxAVXOlsj3snfbQ1dw==",
+            "version": "7.21.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
+            "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@google-cloud/paginator": "^3.0.7",
-                "@google-cloud/projectify": "^3.0.0",
-                "@google-cloud/promisify": "^3.0.0",
+                "@google-cloud/paginator": "^5.0.0",
+                "@google-cloud/projectify": "^4.0.0",
+                "@google-cloud/promisify": "<4.1.0",
                 "abort-controller": "^3.0.0",
                 "async-retry": "^1.3.3",
-                "compressible": "^2.0.12",
-                "duplexify": "^4.0.0",
-                "ent": "^2.2.0",
-                "extend": "^3.0.2",
-                "fast-xml-parser": "^4.2.2",
-                "gaxios": "^5.0.0",
-                "google-auth-library": "^8.0.1",
+                "duplexify": "^4.1.3",
+                "fast-xml-parser": "^5.3.4",
+                "gaxios": "^6.0.2",
+                "google-auth-library": "^9.6.3",
+                "html-entities": "^2.5.2",
                 "mime": "^3.0.0",
-                "mime-types": "^2.0.8",
                 "p-limit": "^3.0.1",
-                "retry-request": "^5.0.0",
-                "teeny-request": "^8.0.0",
-                "uuid": "^8.0.0"
+                "retry-request": "^7.0.0",
+                "teeny-request": "^9.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14"
+            }
+        },
+        "node_modules/@google-cloud/storage/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@google-cloud/storage/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@google-cloud/storage/node_modules/gaxios": {
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+            "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "is-stream": "^2.0.0",
+                "node-fetch": "^2.6.9",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+            "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "gaxios": "^6.1.1",
+                "google-logging-utils": "^0.0.2",
+                "json-bigint": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+            "version": "9.15.1",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+            "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "base64-js": "^1.3.0",
+                "ecdsa-sig-formatter": "^1.0.11",
+                "gaxios": "^6.1.1",
+                "gcp-metadata": "^6.1.0",
+                "gtoken": "^7.0.0",
+                "jws": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+            "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@google-cloud/storage/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/@google-cloud/storage/node_modules/mime": {
@@ -1375,41 +1494,37 @@
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/@google-cloud/storage/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+        "node_modules/@google-cloud/storage/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT",
-            "optional": true,
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
+            "optional": true
         },
         "node_modules/@grpc/grpc-js": {
-            "version": "1.8.22",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.22.tgz",
-            "integrity": "sha512-oAjDdN7fzbUi+4hZjKG96MR6KTEubAeMpQEb+77qy+3r0Ua5xTFuie6JOLr4ZZgl5g+W5/uRTS2M1V8mVAFPuA==",
+            "version": "1.14.4",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+            "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@grpc/proto-loader": "^0.7.0",
-                "@types/node": ">=12.12.47"
+                "@grpc/proto-loader": "^0.8.0",
+                "@js-sdsl/ordered-map": "^4.4.2"
             },
             "engines": {
-                "node": "^8.13.0 || >=10.10.0"
+                "node": ">=12.10.0"
             }
         },
         "node_modules/@grpc/proto-loader": {
-            "version": "0.7.15",
-            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
-            "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+            "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "lodash.camelcase": "^4.3.0",
                 "long": "^5.0.0",
-                "protobufjs": "^7.2.5",
+                "protobufjs": "^7.5.5",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -1461,6 +1576,53 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
+        },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -1905,17 +2067,15 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@jsdoc/salty": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.12.tgz",
-            "integrity": "sha512-TuB0x50EoAvEX/UEWITd8Mkn3WhiTjSvbTMCLj0BhsQEl5iUzjXdA0bETEVpTk+5TGTLR6QktI9H4hLviVeaAQ==",
-            "license": "Apache-2.0",
+        "node_modules/@js-sdsl/ordered-map": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+            "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+            "license": "MIT",
             "optional": true,
-            "dependencies": {
-                "lodash": "^4.18.1"
-            },
-            "engines": {
-                "node": ">=v12.0.0"
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/js-sdsl"
             }
         },
         "node_modules/@mongodb-js/saslprep": {
@@ -1925,6 +2085,39 @@
             "license": "MIT",
             "dependencies": {
                 "sparse-bitfield": "^3.0.3"
+            }
+        },
+        "node_modules/@nodable/entities": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+            "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ],
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/@opentelemetry/api": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+            "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -1969,13 +2162,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "license": "BSD-3-Clause",
-            "optional": true
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
             "license": "BSD-3-Clause",
             "optional": true
         },
@@ -2388,6 +2574,13 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/caseless": {
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+            "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/@types/connect": {
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2452,17 +2645,6 @@
                 "@types/qs": "*",
                 "@types/range-parser": "*",
                 "@types/send": "*"
-            }
-        },
-        "node_modules/@types/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@types/minimatch": "^5.1.2",
-                "@types/node": "*"
             }
         },
         "node_modules/@types/graceful-fs": {
@@ -2536,13 +2718,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/@types/lodash": {
             "version": "4.14.201",
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.201.tgz",
@@ -2558,42 +2733,11 @@
                 "@types/lodash": "*"
             }
         },
-        "node_modules/@types/long": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-            "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/@types/markdown-it": {
-            "version": "14.1.2",
-            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-            "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-            "optional": true,
-            "dependencies": {
-                "@types/linkify-it": "^5",
-                "@types/mdurl": "^2"
-            }
-        },
-        "node_modules/@types/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/@types/mime": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
             "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
             "dev": true
-        },
-        "node_modules/@types/minimatch": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-            "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/@types/morgan": {
             "version": "1.9.9",
@@ -2629,15 +2773,17 @@
             "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
             "dev": true
         },
-        "node_modules/@types/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+        "node_modules/@types/request": {
+            "version": "2.48.13",
+            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+            "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@types/glob": "*",
-                "@types/node": "*"
+                "@types/caseless": "*",
+                "@types/node": "*",
+                "@types/tough-cookie": "*",
+                "form-data": "^2.5.5"
             }
         },
         "node_modules/@types/send": {
@@ -2666,6 +2812,13 @@
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
             "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
             "dev": true
+        },
+        "node_modules/@types/tough-cookie": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+            "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/@types/webidl-conversions": {
             "version": "7.0.3",
@@ -3239,7 +3392,7 @@
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
             "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-            "devOptional": true,
+            "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3251,7 +3404,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "devOptional": true,
+            "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -3421,6 +3574,19 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/anynum": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+            "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/argparse": {
             "version": "1.0.10",
@@ -3603,6 +3769,13 @@
                 "has-symbols": "^1.0.3"
             }
         },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/available-typed-arrays": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -3771,8 +3944,7 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/base64id": {
             "version": "2.0.0",
@@ -3816,7 +3988,6 @@
             "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
             "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": "*"
             }
@@ -3837,13 +4008,6 @@
                 "readable-stream": "^2.3.5",
                 "safe-buffer": "^5.1.1"
             }
-        },
-        "node_modules/bluebird": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/body-parser": {
             "version": "1.20.6",
@@ -4054,19 +4218,6 @@
             ],
             "license": "CC-BY-4.0"
         },
-        "node_modules/catharsis": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
-            "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "lodash": "^4.17.15"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/chai": {
             "version": "4.3.10",
             "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
@@ -4088,7 +4239,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4306,6 +4457,19 @@
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "dev": true
         },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/commander": {
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
@@ -4313,19 +4477,6 @@
             "dev": true,
             "engines": {
                 "node": ">=16"
-            }
-        },
-        "node_modules/compressible": {
-            "version": "2.0.18",
-            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
-            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "mime-db": ">= 1.43.0 < 2"
-            },
-            "engines": {
-                "node": ">= 0.6"
             }
         },
         "node_modules/concat-map": {
@@ -4433,7 +4584,7 @@
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -4449,6 +4600,15 @@
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
             "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
             "dev": true
+        },
+        "node_modules/data-uri-to-buffer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
         },
         "node_modules/debug": {
             "version": "2.6.9",
@@ -4487,7 +4647,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
@@ -4525,6 +4685,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/denque": {
@@ -4651,7 +4821,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/ecdsa-sig-formatter": {
             "version": "1.0.11",
@@ -4689,7 +4859,7 @@
             "version": "9.2.2",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/encodeurl": {
             "version": "2.0.0",
@@ -4787,42 +4957,6 @@
             },
             "engines": {
                 "node": ">=8.6"
-            }
-        },
-        "node_modules/ent": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.2.tgz",
-            "integrity": "sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "es-errors": "^1.3.0",
-                "punycode": "^1.4.1",
-                "safe-regex-test": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/ent/node_modules/punycode": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/error-ex": {
@@ -5050,83 +5184,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/escodegen": {
-            "version": "1.14.3",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "dependencies": {
-                "esprima": "^4.0.1",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1"
-            },
-            "bin": {
-                "escodegen": "bin/escodegen.js",
-                "esgenerate": "bin/esgenerate.js"
-            },
-            "engines": {
-                "node": ">=4.0"
-            },
-            "optionalDependencies": {
-                "source-map": "~0.6.1"
-            }
-        },
-        "node_modules/escodegen/node_modules/levn": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-            "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/optionator": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.6",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "word-wrap": "~1.2.3"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/prelude-ls": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-            "optional": true,
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/type-check": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-            "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "prelude-ls": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
             }
         },
         "node_modules/eslint": {
@@ -5389,18 +5446,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "optional": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
         "node_modules/eslint/node_modules/debug": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -5469,7 +5514,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "devOptional": true,
+            "dev": true,
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -5530,7 +5575,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5666,8 +5711,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -5684,14 +5728,7 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "devOptional": true
-        },
-        "node_modules/fast-text-encoding": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
-            "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
-            "license": "Apache-2.0",
-            "optional": true
+            "dev": true
         },
         "node_modules/fast-uri": {
             "version": "3.1.3",
@@ -5709,10 +5746,10 @@
             ],
             "license": "BSD-3-Clause"
         },
-        "node_modules/fast-xml-parser": {
-            "version": "4.5.7",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.7.tgz",
-            "integrity": "sha512-a6Qh1RMCNbSrU1+sAyAAZH3rTe+OaWJbNZIq0S+ifZciUUOQtlVxBJwoTUE2bYhysmG/RYyI5WJFIKdBahJdrQ==",
+        "node_modules/fast-xml-builder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+            "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
             "funding": [
                 {
                     "type": "github",
@@ -5722,7 +5759,29 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "strnum": "^1.0.5"
+                "path-expression-matcher": "^1.6.2",
+                "xml-naming": "^0.3.0"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+            "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@nodable/entities": "^3.0.0",
+                "fast-xml-builder": "^1.2.0",
+                "is-unsafe": "^2.0.0",
+                "path-expression-matcher": "^1.6.2",
+                "strnum": "^2.4.1",
+                "xml-naming": "^0.3.0"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
@@ -5747,6 +5806,29 @@
             "dev": true,
             "dependencies": {
                 "bser": "2.1.1"
+            }
+        },
+        "node_modules/fetch-blob": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20 || >= 14.13"
             }
         },
         "node_modules/file-entry-cache": {
@@ -5805,26 +5887,25 @@
             }
         },
         "node_modules/firebase-admin": {
-            "version": "11.11.1",
-            "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-11.11.1.tgz",
-            "integrity": "sha512-UyEbq+3u6jWzCYbUntv/HuJiTixwh36G1R9j0v71mSvGAx/YZEWEW7uSGLYxBYE6ckVRQoKMr40PYUEzrm/4dg==",
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-14.2.0.tgz",
+            "integrity": "sha512-zfs5PdccEgjX479bbMmz95Rqc7ttQ4LV3qkGFlPiqOaOu/suBZc3fG52Qzn2hQjiSHkBM4NP2AZV5r2NvAt0TQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@fastify/busboy": "^1.2.1",
-                "@firebase/database-compat": "^0.3.4",
-                "@firebase/database-types": "^0.10.4",
-                "@types/node": ">=12.12.47",
+                "@fastify/busboy": "^3.0.0",
+                "@firebase/database-compat": "^2.1.4",
+                "@firebase/database-types": "^1.0.20",
+                "fast-deep-equal": "^3.1.1",
+                "google-auth-library": "^10.6.2",
                 "jsonwebtoken": "^9.0.0",
-                "jwks-rsa": "^3.0.1",
-                "node-forge": "^1.3.1",
-                "uuid": "^9.0.0"
+                "jwks-rsa": "^4.0.1"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=22"
             },
             "optionalDependencies": {
-                "@google-cloud/firestore": "^6.8.0",
-                "@google-cloud/storage": "^6.9.5"
+                "@google-cloud/firestore": "^8.6.0",
+                "@google-cloud/storage": "^7.19.0"
             }
         },
         "node_modules/flat-cache": {
@@ -5854,6 +5935,66 @@
             "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
             "dependencies": {
                 "is-callable": "^1.1.3"
+            }
+        },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/foreground-child/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "license": "ISC",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+            "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.12"
+            }
+        },
+        "node_modules/formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "license": "MIT",
+            "dependencies": {
+                "fetch-blob": "^3.1.2"
+            },
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/forwarded": {
@@ -5928,36 +6069,6 @@
             "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/gaxios": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-            "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "extend": "^3.0.2",
-                "https-proxy-agent": "^5.0.0",
-                "is-stream": "^2.0.0",
-                "node-fetch": "^2.6.9"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/gcp-metadata": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-            "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "gaxios": "^5.0.0",
-                "json-bigint": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/gensync": {
@@ -6119,117 +6230,398 @@
             }
         },
         "node_modules/google-auth-library": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.9.0.tgz",
-            "integrity": "sha512-f7aQCJODJFmYWN6PeNKzgvy9LI2tYmXnzpNDHEjG5sDNPgGb2FXQyTBnXeSH+PAtpKESFD+LmHw3Ox3mN7e1Fg==",
+            "version": "10.9.0",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+            "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
             "license": "Apache-2.0",
-            "optional": true,
             "dependencies": {
-                "arrify": "^2.0.0",
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
-                "fast-text-encoding": "^1.0.0",
-                "gaxios": "^5.0.0",
-                "gcp-metadata": "^5.3.0",
-                "gtoken": "^6.1.0",
-                "jws": "^4.0.0",
-                "lru-cache": "^6.0.0"
+                "gaxios": "^7.1.4",
+                "gcp-metadata": "8.1.2",
+                "google-logging-utils": "1.1.3",
+                "jws": "^4.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
-        "node_modules/google-auth-library/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "license": "ISC",
-            "optional": true,
+        "node_modules/google-auth-library/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/google-auth-library/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
             "dependencies": {
-                "yallist": "^4.0.0"
+                "ms": "^2.1.3"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/google-auth-library/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "license": "ISC",
-            "optional": true
+        "node_modules/google-auth-library/node_modules/gaxios": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+            "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "node-fetch": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/google-auth-library/node_modules/gcp-metadata": {
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+            "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "gaxios": "^7.0.0",
+                "google-logging-utils": "^1.0.0",
+                "json-bigint": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/google-auth-library/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/google-auth-library/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/google-auth-library/node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "license": "MIT",
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
+            }
         },
         "node_modules/google-gax": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.6.1.tgz",
-            "integrity": "sha512-g/lcUjGcB6DSw2HxgEmCDOrI/CByOwqRvsuUvNalHUK2iPPPlmAIpbMbl62u0YufGMr8zgE3JL7th6dCb1Ry+w==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.7.tgz",
+            "integrity": "sha512-EhiqaWWJ+9h7sCcKJTsoo6tMcjokVHhWsbSuWCnZJT4vIBP3y4mAoFLnt9SzgkVZeq24ZsFaArr06nnYYku2yA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@grpc/grpc-js": "~1.8.0",
-                "@grpc/proto-loader": "^0.7.0",
-                "@types/long": "^4.0.0",
-                "@types/rimraf": "^3.0.2",
-                "abort-controller": "^3.0.0",
-                "duplexify": "^4.0.0",
-                "fast-text-encoding": "^1.0.3",
-                "google-auth-library": "^8.0.2",
-                "is-stream-ended": "^0.1.4",
-                "node-fetch": "^2.6.1",
+                "@grpc/grpc-js": "^1.12.6",
+                "@grpc/proto-loader": "^0.8.0",
+                "duplexify": "^4.1.3",
+                "google-auth-library": "10.5.0",
+                "google-logging-utils": "1.1.3",
+                "node-fetch": "^3.3.2",
                 "object-hash": "^3.0.0",
-                "proto3-json-serializer": "^1.0.0",
-                "protobufjs": "7.2.4",
-                "protobufjs-cli": "1.1.1",
-                "retry-request": "^5.0.0"
-            },
-            "bin": {
-                "compileProtos": "build/tools/compileProtos.js",
-                "minifyProtoJson": "build/tools/minify.js"
+                "proto3-json-serializer": "3.0.4",
+                "protobufjs": "^7.5.4",
+                "retry-request": "^8.0.2",
+                "rimraf": "^5.0.1"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
-        "node_modules/google-gax/node_modules/protobufjs": {
-            "version": "7.2.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-            "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
-            "hasInstallScript": true,
-            "license": "BSD-3-Clause",
+        "node_modules/google-gax/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
             "optional": true,
-            "dependencies": {
-                "@protobufjs/aspromise": "^1.1.2",
-                "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.4",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
-                "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.0",
-                "@protobufjs/path": "^1.1.2",
-                "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.0",
-                "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
-            },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">= 14"
             }
         },
-        "node_modules/google-p12-pem": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
-            "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
-            "deprecated": "Package is no longer maintained",
+        "node_modules/google-gax/node_modules/brace-expansion": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "node-forge": "^1.3.1"
-            },
-            "bin": {
-                "gp12-pem": "build/src/bin/gp12-pem.js"
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/google-gax/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ms": "^2.1.3"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/google-gax/node_modules/gaxios": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+            "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "node-fetch": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/google-gax/node_modules/gcp-metadata": {
+            "version": "8.1.3",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.3.tgz",
+            "integrity": "sha512-ziTrzUhhpL9Zk5k0HHzgP/KIpWDJT0VMBC/ynt/QIBvTW+UUcSivQRl6VlwTf/EilDxtSWklHoRsKy1c4k+59w==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "gaxios": "7.1.3",
+                "google-logging-utils": "1.1.3",
+                "json-bigint": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/google-gax/node_modules/gcp-metadata/node_modules/gaxios": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+            "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "node-fetch": "^3.3.2",
+                "rimraf": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/google-gax/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/google-gax/node_modules/google-auth-library": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+            "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "base64-js": "^1.3.0",
+                "ecdsa-sig-formatter": "^1.0.11",
+                "gaxios": "^7.0.0",
+                "gcp-metadata": "^8.0.0",
+                "google-logging-utils": "^1.0.0",
+                "gtoken": "^8.0.0",
+                "jws": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/google-gax/node_modules/gtoken": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+            "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "gaxios": "^7.0.0",
+                "jws": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/google-gax/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/google-gax/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/google-gax/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/google-gax/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/google-gax/node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
+            }
+        },
+        "node_modules/google-gax/node_modules/retry-request": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.3.tgz",
+            "integrity": "sha512-qqoc4kkGgP9cmQDWELlOpAmfgJOg0Yi7MT82ZjiPWu451ayju4itwomjM4/dBEliify8C1b3tSaeCOldugtwPQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "extend": "^3.0.2",
+                "teeny-request": "^10.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/google-gax/node_modules/rimraf": {
+            "version": "5.0.10",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+            "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "glob": "^10.3.7"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/google-gax/node_modules/teeny-request": {
+            "version": "10.1.3",
+            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.3.tgz",
+            "integrity": "sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.1",
+                "node-fetch": "^3.3.2",
+                "stream-events": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/google-logging-utils": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+            "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/gopd": {
@@ -6250,19 +6642,84 @@
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
         "node_modules/gtoken": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
-            "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+            "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "gaxios": "^5.0.1",
-                "google-p12-pem": "^4.0.0",
+                "gaxios": "^6.0.0",
                 "jws": "^4.0.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
+        },
+        "node_modules/gtoken/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/gtoken/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/gtoken/node_modules/gaxios": {
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+            "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "is-stream": "^2.0.0",
+                "node-fetch": "^2.6.9",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/gtoken/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/gtoken/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/has-bigints": {
             "version": "1.0.2",
@@ -6345,6 +6802,23 @@
             "version": "2.8.9",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
             "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+        },
+        "node_modules/html-entities": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+            "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/mdevils"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://patreon.com/mdevils"
+                }
+            ],
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/html-escaper": {
             "version": "2.0.2",
@@ -6843,13 +7317,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-stream-ended": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
-            "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/is-string": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -6891,6 +7358,19 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/is-unsafe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+            "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/is-weakmap": {
             "version": "2.0.1",
@@ -7035,6 +7515,22 @@
                 "has-symbols": "^1.0.3",
                 "reflect.getprototypeof": "^1.0.4",
                 "set-function-name": "^2.0.1"
+            }
+        },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "license": "BlueOak-1.0.0",
+            "optional": true,
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
             }
         },
         "node_modules/jest": {
@@ -7677,9 +8173,9 @@
             }
         },
         "node_modules/jose": {
-            "version": "4.15.9",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-            "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+            "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
@@ -7705,56 +8201,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/js2xmlparser": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
-            "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "xmlcreate": "^2.0.4"
-            }
-        },
-        "node_modules/jsdoc": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
-            "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "@babel/parser": "^7.20.15",
-                "@jsdoc/salty": "^0.2.1",
-                "@types/markdown-it": "^14.1.1",
-                "bluebird": "^3.7.2",
-                "catharsis": "^0.9.0",
-                "escape-string-regexp": "^2.0.0",
-                "js2xmlparser": "^4.0.2",
-                "klaw": "^3.0.0",
-                "markdown-it": "^14.1.0",
-                "markdown-it-anchor": "^8.6.7",
-                "marked": "^4.0.10",
-                "mkdirp": "^1.0.4",
-                "requizzle": "^0.2.3",
-                "strip-json-comments": "^3.1.0",
-                "underscore": "~1.13.2"
-            },
-            "bin": {
-                "jsdoc": "jsdoc.js"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/jsdoc/node_modules/escape-string-regexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/jsesc": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -7773,7 +8219,6 @@
             "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
             "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "bignumber.js": "^9.0.0"
             }
@@ -7881,19 +8326,20 @@
             }
         },
         "node_modules/jwks-rsa": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.2.tgz",
-            "integrity": "sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-4.1.0.tgz",
+            "integrity": "sha512-sbkByqyATKYJP5F4RXj03N5TUNC0QLTjCAZvwTzC4BwJZ8e0/cWxN8YROnyUth2g1/ONWi4eSFHeu6oYalrc3Q==",
             "license": "MIT",
             "dependencies": {
                 "@types/jsonwebtoken": "^9.0.4",
                 "debug": "^4.3.4",
-                "jose": "^4.15.4",
+                "jose": "^6.1.3",
                 "limiter": "^1.1.5",
-                "lru-memoizer": "^2.2.0"
+                "lru-cache": "^11.0.0",
+                "lru-memoizer": "^3.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
             }
         },
         "node_modules/jwks-rsa/node_modules/debug": {
@@ -7911,6 +8357,15 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/jwks-rsa/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/jwks-rsa/node_modules/ms": {
@@ -7945,16 +8400,6 @@
             "dev": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
-            }
-        },
-        "node_modules/klaw": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-            "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "graceful-fs": "^4.1.9"
             }
         },
         "node_modules/kleur": {
@@ -8025,26 +8470,6 @@
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
-        },
-        "node_modules/linkify-it": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
-            "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/puzrin"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/markdown-it"
-                }
-            ],
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "uc.micro": "^2.0.0"
-            }
         },
         "node_modules/lint-staged": {
             "version": "13.3.0",
@@ -8479,32 +8904,23 @@
             }
         },
         "node_modules/lru-memoizer": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
-            "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-3.0.0.tgz",
+            "integrity": "sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==",
             "license": "MIT",
             "dependencies": {
                 "lodash.clonedeep": "^4.5.0",
-                "lru-cache": "6.0.0"
+                "lru-cache": "^11.0.1"
             }
         },
         "node_modules/lru-memoizer/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=10"
+                "node": "20 || >=22"
             }
-        },
-        "node_modules/lru-memoizer/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "license": "ISC"
         },
         "node_modules/make-dir": {
             "version": "4.0.0",
@@ -8530,65 +8946,6 @@
                 "tmpl": "1.0.5"
             }
         },
-        "node_modules/markdown-it": {
-            "version": "14.3.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
-            "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/puzrin"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/markdown-it"
-                }
-            ],
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "argparse": "^2.0.1",
-                "entities": "^4.5.0",
-                "linkify-it": "^5.0.2",
-                "mdurl": "^2.0.0",
-                "punycode.js": "^2.3.1",
-                "uc.micro": "^2.1.0"
-            },
-            "bin": {
-                "markdown-it": "bin/markdown-it.mjs"
-            }
-        },
-        "node_modules/markdown-it-anchor": {
-            "version": "8.6.7",
-            "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
-            "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
-            "license": "Unlicense",
-            "optional": true,
-            "peerDependencies": {
-                "@types/markdown-it": "*",
-                "markdown-it": "*"
-            }
-        },
-        "node_modules/markdown-it/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "license": "Python-2.0",
-            "optional": true
-        },
-        "node_modules/marked": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-            "license": "MIT",
-            "optional": true,
-            "bin": {
-                "marked": "bin/marked.js"
-            },
-            "engines": {
-                "node": ">= 12"
-            }
-        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8597,13 +8954,6 @@
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/media-typer": {
             "version": "0.3.0",
@@ -8718,7 +9068,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "devOptional": true,
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -8812,16 +9162,14 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
-        "node_modules/mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+        "node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "license": "BlueOak-1.0.0",
             "optional": true,
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
             "engines": {
-                "node": ">=10"
+                "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/mongodb": {
@@ -9057,6 +9405,26 @@
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "deprecated": "Use your platform's native DOMException instead",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.5.0"
+            }
+        },
         "node_modules/node-fetch": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -9101,15 +9469,6 @@
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
-            }
-        },
-        "node_modules/node-forge": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-            "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-            "license": "(BSD-3-Clause OR GPL-2.0)",
-            "engines": {
-                "node": ">= 6.13.0"
             }
         },
         "node_modules/node-gyp-build": {
@@ -9649,6 +10008,13 @@
                 "node": ">=6"
             }
         },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "license": "BlueOak-1.0.0",
+            "optional": true
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9697,6 +10063,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-expression-matcher": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+            "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -9709,7 +10091,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=8"
             }
@@ -9718,6 +10100,30 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+        },
+        "node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "license": "BlueOak-1.0.0",
+            "optional": true,
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/path-to-regexp": {
             "version": "0.1.13",
@@ -9870,16 +10276,16 @@
             }
         },
         "node_modules/proto3-json-serializer": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.1.1.tgz",
-            "integrity": "sha512-AwAuY4g9nxx0u52DnSMkqqgyLHaW/XaPLtaAo3y/ZCfeaQB/g4YDH4kb8Wc/mWzWvu0YjOznVnfn373MVZZrgw==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+            "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "protobufjs": "^7.0.0"
+                "protobufjs": "^7.4.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/protobufjs": {
@@ -9887,6 +10293,7 @@
             "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
             "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
             "hasInstallScript": true,
+            "license": "BSD-3-Clause",
             "optional": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
@@ -9903,120 +10310,6 @@
             },
             "engines": {
                 "node": ">=12.0.0"
-            }
-        },
-        "node_modules/protobufjs-cli": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.1.1.tgz",
-            "integrity": "sha512-VPWMgIcRNyQwWUv8OLPyGQ/0lQY/QTQAVN5fh+XzfDwsVw1FZ2L3DM/bcBf8WPiRz2tNpaov9lPZfNcmNo6LXA==",
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "escodegen": "^1.13.0",
-                "espree": "^9.0.0",
-                "estraverse": "^5.1.0",
-                "glob": "^8.0.0",
-                "jsdoc": "^4.0.0",
-                "minimist": "^1.2.0",
-                "semver": "^7.1.2",
-                "tmp": "^0.2.1",
-                "uglify-js": "^3.7.7"
-            },
-            "bin": {
-                "pbjs": "bin/pbjs",
-                "pbts": "bin/pbts"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "protobufjs": "^7.0.0"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/acorn": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-            "license": "MIT",
-            "optional": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/espree": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "dependencies": {
-                "acorn": "^8.9.0",
-                "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/minimatch": {
-            "version": "5.1.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/proxy-addr": {
@@ -10040,16 +10333,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/punycode.js": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-            "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">=6"
             }
@@ -10243,16 +10526,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/requizzle": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
-            "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "lodash": "^4.17.21"
-            }
-        },
         "node_modules/resolve": {
             "version": "1.22.8",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -10335,43 +10608,19 @@
             }
         },
         "node_modules/retry-request": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.2.tgz",
-            "integrity": "sha512-wfI3pk7EE80lCIXprqh7ym48IHYdwmAAzESdbU8Q9l7pnRCk9LEhpbOTNKjz6FARLm/Bl5m+4F0ABxOkYUujSQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+            "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "debug": "^4.1.1",
-                "extend": "^3.0.2"
+                "@types/request": "^2.48.8",
+                "extend": "^3.0.2",
+                "teeny-request": "^9.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14"
             }
-        },
-        "node_modules/retry-request/node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/retry-request/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/rfdc": {
             "version": "1.3.0",
@@ -10634,7 +10883,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -10646,7 +10895,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=8"
             }
@@ -11057,7 +11306,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
             "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "eastasianwidth": "^0.2.0",
                 "emoji-regex": "^9.2.2",
@@ -11070,11 +11319,44 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/string-width/node_modules/ansi-regex": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
             "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=12"
             },
@@ -11086,7 +11368,7 @@
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
             "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -11167,6 +11449,20 @@
                 "node": ">=8"
             }
         },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-bom": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
@@ -11189,7 +11485,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=8"
             },
@@ -11198,9 +11494,9 @@
             }
         },
         "node_modules/strnum": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-            "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+            "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
             "funding": [
                 {
                     "type": "github",
@@ -11208,7 +11504,10 @@
                 }
             ],
             "license": "MIT",
-            "optional": true
+            "optional": true,
+            "dependencies": {
+                "anynum": "^1.0.1"
+            }
         },
         "node_modules/stubs": {
             "version": "3.0.0",
@@ -11221,7 +11520,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -11339,20 +11638,20 @@
             }
         },
         "node_modules/teeny-request": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-8.0.3.tgz",
-            "integrity": "sha512-jJZpA5He2y52yUhA7pyAGZlgQpcB+xLjcN0eUFxr9c8hP/H7uOXbBNVo/O0C/xVfJLJs680jvkFgVJEEvk9+ww==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+            "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "http-proxy-agent": "^5.0.0",
                 "https-proxy-agent": "^5.0.0",
-                "node-fetch": "^2.6.1",
+                "node-fetch": "^2.6.9",
                 "stream-events": "^1.0.5",
                 "uuid": "^9.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14"
             }
         },
         "node_modules/terser": {
@@ -11415,27 +11714,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/text-decoding": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/text-decoding/-/text-decoding-1.0.0.tgz",
-            "integrity": "sha512-/0TJD42KDnVwKmDK6jj3xP7E2MG7SHAOG4tyTgyUCRPdHwvkquYNLEQltmdMa3owq3TkddCVcTsoctJI8VQNKA==",
-            "license": "MIT"
-        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
-        },
-        "node_modules/tmp": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
-            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=14.14"
-            }
         },
         "node_modules/tmpl": {
             "version": "1.0.5",
@@ -11698,26 +11981,6 @@
                 "@typescript/typescript-win32-x64": "7.0.2"
             }
         },
-        "node_modules/uc.micro": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/uglify-js": {
-            "version": "3.19.3",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-            "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "bin": {
-                "uglifyjs": "bin/uglifyjs"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/unbox-primitive": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -11736,13 +11999,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
             "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
-        },
-        "node_modules/underscore": {
-            "version": "1.13.8",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
-            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/undici-types": {
             "version": "5.26.5",
@@ -11833,6 +12089,7 @@
                 "https://github.com/sponsors/ctavan"
             ],
             "license": "MIT",
+            "optional": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -11893,6 +12150,15 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/webidl-conversions": {
@@ -12031,7 +12297,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -12122,21 +12388,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/word-wrap": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/wrap-ansi": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
             "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "ansi-styles": "^6.1.0",
                 "string-width": "^5.0.1",
@@ -12149,11 +12405,62 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/wrap-ansi/node_modules/ansi-regex": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
             "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=12"
             },
@@ -12165,7 +12472,7 @@
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
             "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=12"
             },
@@ -12177,7 +12484,7 @@
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
             "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -12227,12 +12534,21 @@
                 }
             }
         },
-        "node_modules/xmlcreate": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
-            "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
-            "license": "Apache-2.0",
-            "optional": true
+        "node_modules/xml-naming": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+            "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=16.0.0"
+            }
         },
         "node_modules/y18n": {
             "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "debug": "~2.6.9",
         "dotenv": "^17.4.2",
         "express": "^4.16.4",
-        "firebase-admin": "^11.4.1",
+        "firebase-admin": "^14.2.0",
         "lodash": "^4.17.21",
         "lodash.isequal": "^4.5.0",
         "mongodb": "^3.6.3",


### PR DESCRIPTION
## Summary
- Bumps `firebase-admin` 11.4.1 → 14.2.0, resolving the remaining critical/high vulnerabilities left over from #96 (`protobufjs`, `protobufjs-cli`, `@grpc/grpc-js`, `fast-xml-parser`), all transitive through firebase-admin's own `google-gax`/`@google-cloud/firestore` dependency chain.
- This repo's only usage of the SDK is in `src/utils/firebaseAdmin.ts`: `initializeApp`, `cert`, `getApps` from `firebase-admin/app`, and `getAuth().verifyIdToken` from `firebase-admin/auth`. None of these were touched by v12–v14's breaking changes (legacy namespace removal, Instance ID service removal, legacy FCM types) since this code already uses the modular imports exclusively.
- firebase-admin v14 requires Node 22+; this repo already pins Node 24.15.0 in `package.json` engines, so no impact there.
- Verified by hand (not exercised by the Jest suite, since `firebaseAdmin.ts` intentionally defers its `require()` calls to avoid a Jest/ESM interop issue — see the comment in that file) that:
  - `initializeApp`/`cert`/`getAuth` still load and initialize correctly with a real key
  - `verifyIdToken` on a bogus token still rejects the same way (`auth/argument-error`), so `requireAuth`/`optionalAuth` in `src/middleware/auth.ts` behave unchanged

## Remaining alerts (not in scope here)
- `morgan` needs to move outside its pinned `~1.9.1` range to fix log forging + `on-headers`
- `lint-staged` (dev-only) needs a bump beyond `^13.0.4` to fix `micromatch` + `yaml`
- One `uuid@9.0.1` moderate alert is pinned several layers deep inside firebase-admin's own `gaxios`/`@google-cloud/storage` dependency and isn't resolvable from this repo without an npm override

## Test plan
- [x] `npm run build` (tsc) — clean
- [x] `npm test` — 270/270 passing
- [x] Manual smoke test of `firebase-admin/app` + `firebase-admin/auth` init and token-rejection path with a real RSA key