### PR TITLE
chore(deps): upgrade morgan to 1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "lodash.isequal": "^4.5.0",
                 "mongodb": "^3.6.3",
                 "mongoose": "^8.0.0",
-                "morgan": "~1.9.1",
+                "morgan": "~1.11.0",
                 "nodemon": "^3.0.1",
                 "npm-run-all": "^4.1.5",
                 "rimraf": "^3.0.2",
@@ -9303,37 +9303,23 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/morgan": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
-            "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
+            "integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
+            "license": "MIT",
             "dependencies": {
-                "basic-auth": "~2.0.0",
+                "basic-auth": "~2.0.1",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "on-finished": "~2.3.0",
-                "on-headers": "~1.0.1"
+                "depd": "~2.0.0",
+                "on-finished": "~2.4.1",
+                "on-headers": "~1.1.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/morgan/node_modules/depd": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-            "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/morgan/node_modules/on-finished": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-            "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-            "dependencies": {
-                "ee-first": "1.1.1"
             },
-            "engines": {
-                "node": ">= 0.8"
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/mpath": {
@@ -9899,9 +9885,10 @@
             }
         },
         "node_modules/on-headers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+            "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "lodash.isequal": "^4.5.0",
         "mongodb": "^3.6.3",
         "mongoose": "^8.0.0",
-        "morgan": "~1.9.1",
+        "morgan": "~1.11.0",
         "nodemon": "^3.0.1",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",


### PR DESCRIPTION
## Summary
- Bumps `morgan` from `~1.9.1` to `~1.11.0`, fixing the log-forging advisory (GHSA-4vj7-5mj6-jm8m, unescaped control chars in `:remote-user`) and the `on-headers` header-manipulation advisory it depended on.
- `src/app.ts` only uses the `'dev'` format, which never includes `:remote-user`, so this app wasn't substantively exposed — patching just removes the alert.
- Checked morgan's own changelog between 1.9.1 and 1.11.0: no breaking changes, no changes to the default export or the `dev` format — purely additive tokens (`:total-time`, `:pid`) and dependency security bumps.

## Test plan
- [x] `npm run build` (tsc) — clean
- [x] `npm test` — 270/270 passing