### PR TITLE
fix(user): stop game history 404s after a room is deleted

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -58,7 +58,7 @@ export const removeGame = async (uid: string, gameId: string) => {
     const myUser = await getUser(uid);
     if (myUser) {
         console.info(`Removing game ${typeof gameId} ${gameId} from ${uid}`);
-        if (myUser.games.includes(uid)) {
+        if (myUser.games.includes(gameId)) {
             myUser.games = myUser.games.filter((game) => game !== gameId);
             await myUser.save();
         }
@@ -87,22 +87,6 @@ export const unarchiveGame = async (uid: string, gameId: string) => {
         myUser.archivedGames = myUser.archivedGames.filter((game) => game !== gameId);
         await myUser.save();
         return myUser;
-    }
-    console.error('User not found');
-};
-
-export const getGames = async (uid: string) => {
-    const myUser = await getUser(uid);
-    if (myUser) {
-        return myUser.games;
-    }
-    console.error('User not found');
-};
-
-export const getRank = async (uid: string) => {
-    const myUser = await getUser(uid);
-    if (myUser) {
-        return myUser.rank;
     }
     console.error('User not found');
 };

--- a/src/routes/user/index.ts
+++ b/src/routes/user/index.ts
@@ -10,8 +10,6 @@ import {
     removeGame,
     archiveGame,
     unarchiveGame,
-    getGames,
-    getRank,
     setRank,
 } from '../../controllers/userController';
 import { requireAuth } from '../../middleware/auth';
@@ -64,8 +62,13 @@ user.post('/:userId/games/:gameId', async (req, res) => {
         res.status(404).send('User not found');
     }
 });
-user.delete('/:userId/games/:gameId', (req, res) => {
-    removeGame(req.params.userId, req.params.gameId);
+user.delete('/:userId/games/:gameId', async (req, res) => {
+    const myUser = await removeGame(req.params.userId, req.params.gameId);
+    if (myUser) {
+        res.status(200).send(myUser);
+    } else {
+        res.status(404).send('User not found');
+    }
 });
 user.post('/:userId/games/:gameId/archive', async (req, res) => {
     const myUser = await archiveGame(req.params.userId, req.params.gameId);
@@ -83,10 +86,29 @@ user.delete('/:userId/games/:gameId/archive', async (req, res) => {
         res.status(404).send('User not found');
     }
 });
-user.get('/:userId/games', getGames);
-user.get('/:userId/rank', getRank);
-user.put('/:userId/rank', (req, res) => {
-    setRank(req.params.userId, req.body.rank);
+user.get('/:userId/games', async (req, res) => {
+    const myUser = await getUser(req.params.userId);
+    if (myUser) {
+        res.status(200).send(myUser.games);
+    } else {
+        res.status(404).send('User not found');
+    }
+});
+user.get('/:userId/rank', async (req, res) => {
+    const myUser = await getUser(req.params.userId);
+    if (myUser) {
+        res.status(200).send({ rank: myUser.rank });
+    } else {
+        res.status(404).send('User not found');
+    }
+});
+user.put('/:userId/rank', async (req, res) => {
+    const myUser = await setRank(req.params.userId, req.body.rank);
+    if (myUser) {
+        res.status(200).send(myUser);
+    } else {
+        res.status(404).send('User not found');
+    }
 });
 
 export default user;


### PR DESCRIPTION
## Summary

Fixes chinese-board-games/luzhanqi-web#168 ("authed user cannot get game history", `AxiosError...404`, reported to occur after deleting a room).

**Root cause:** `removeGame` in `userController.ts` checked `myUser.games.includes(uid)` instead of `includes(gameId)`. When a host deletes a room (the host-leaves flow in `lzqgame.ts`), the backend deletes the `Game` document and calls `removeGame(uid, gameId)` for each player to strip it from their history — but the typo made that check always false, so the cleanup silently never ran. The deleted game's id stayed in the user's `games` list permanently. The frontend's game-history view later fetches each id via `GET /games/:gameId`, which correctly 404s for an id that no longer exists — that's the error in the issue.

**Also found while tracing the call path:** four routes in the same file never sent an HTTP response at all:
- `GET /:userId/games` and `GET /:userId/rank` wired the Express route directly to a controller function typed `(uid: string)`. Express calls route handlers as `(req, res, next)`, so the handler received the `Request` object where it expected a uid string, and never called `res.send`.
- `PUT /:userId/rank` and `DELETE /:userId/games/:gameId` called their controller functions but never awaited them or sent a response.

All four now `await` their result and respond `200`/`404`, matching the pattern already used by every other route in this file.

`getGames`/`getRank` are removed rather than fixed-in-place: each was a one-line `getUser()` + field pluck, called from exactly one place (verified via repo-wide grep). Inlining `getUser()` directly in the two `GET` routes — matching the existing `GET /:userId` route right above them — sidesteps a subtler bug an in-place fix would've kept: `rank` has no schema default (`models/User.ts`), so a legacy user with no rank set is indistinguishable from "user not found" if the route infers not-found from the return value being `undefined`.

## Test plan
- [x] `npm run build` (tsc) — clean
- [x] `npm test` — 270/270 passing (no existing coverage on this router)
- [x] Verified end-to-end against a real local `mongod` (not just Jest, which doesn't touch this file): seeded a user with an orphaned game id, called `removeGame`, confirmed it's actually stripped from `games`; invoked all four previously-silent route handlers directly and confirmed each now returns `200` with the expected body instead of hanging indefinitely