### PR TITLE
chore: use base64 encoding for firebase api key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ e.g. `fix(lzqgame): ...`).
 - `src/server.ts` — HTTP + socket.io bootstrap, CORS allowlist
 - `src/lzqgame.ts` — all socket.io event handlers (join/rejoin/move/setup/AI turns). Thin wrappers where possible; real logic lives in `services/`. Also owns the auth/ownership checks for socket events — see "Authentication & authorization" below
 - `src/middleware/auth.ts` — `requireAuth`/`optionalAuth` Express middleware verifying a Firebase ID token from the `Authorization: Bearer <token>` header (sets `req.uid`)
-- `src/utils/firebaseAdmin.ts` — `verifyIdToken`; lazily initializes the Firebase Admin SDK from `FIREBASE_PROJECT_ID`/`FIREBASE_CLIENT_EMAIL`/`FIREBASE_PRIVATE_KEY` env vars
+- `src/utils/firebaseAdmin.ts` — `verifyIdToken`; lazily initializes the Firebase Admin SDK from `FIREBASE_PROJECT_ID`/`FIREBASE_CLIENT_EMAIL`/`FIREBASE_PRIVATE_KEY_B64` env vars
 - `src/services/gameplayService.ts` — socket-free move/setup application (`applyMove`, `submitInitialBoard`, `pieceMovement`, `broadcastGameState`) — reused by both real player handlers and the AI's own turns. Prefer adding new gameplay logic here over `lzqgame.ts` so it stays testable without a socket
 - `src/controllers/` — Mongoose DB access (`gameController.ts`, `userController.ts`)
 - `src/models/Game.ts` — the `Game` schema (board, players, turn/phase, reconnection tokens, join code, rule-variant config, AI config)
@@ -65,8 +65,8 @@ invalid* one is treated as an error, not silently downgraded to anonymous.
   reconnection token — losing it (e.g. a server restart) doesn't affect
   reconnection, only same-session seat spoofing.
 - Local dev without `FIREBASE_PROJECT_ID`/`FIREBASE_CLIENT_EMAIL`/
-  `FIREBASE_PRIVATE_KEY` set works fine for anonymous flows (no token ever
-  reaches `verifyIdToken`) but throws the moment a real token needs
+  `FIREBASE_PRIVATE_KEY_B64` set works fine for anonymous flows (no token
+  ever reaches `verifyIdToken`) but throws the moment a real token needs
   verifying.
 
 ## Known gotchas

--- a/src/utils/firebaseAdmin.ts
+++ b/src/utils/firebaseAdmin.ts
@@ -17,20 +17,21 @@ function getAdminApp(): App {
     if (existing) {
         return existing;
     }
-    const { FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, FIREBASE_PRIVATE_KEY } =
+    const { FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, FIREBASE_PRIVATE_KEY_B64 } =
         process.env;
-    if (!FIREBASE_PROJECT_ID || !FIREBASE_CLIENT_EMAIL || !FIREBASE_PRIVATE_KEY) {
+    if (!FIREBASE_PROJECT_ID || !FIREBASE_CLIENT_EMAIL || !FIREBASE_PRIVATE_KEY_B64) {
         throw new Error(
-            'Firebase Admin credentials are not configured (FIREBASE_PROJECT_ID / FIREBASE_CLIENT_EMAIL / FIREBASE_PRIVATE_KEY)',
+            'Firebase Admin credentials are not configured (FIREBASE_PROJECT_ID / FIREBASE_CLIENT_EMAIL / FIREBASE_PRIVATE_KEY_B64)',
         );
     }
     return initializeApp({
         credential: cert({
             projectId: FIREBASE_PROJECT_ID,
             clientEmail: FIREBASE_CLIENT_EMAIL,
-            // .env can't hold literal newlines, so the key is stored with
-            // escaped \n sequences that need to be restored here
-            privateKey: FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n'),
+            // stored base64-encoded so host dashboards (Render, etc.) can't
+            // mangle embedded newlines/quotes the way they can with a raw
+            // escaped-\n PEM string
+            privateKey: Buffer.from(FIREBASE_PRIVATE_KEY_B64, 'base64').toString('utf8'),
         }),
     });
 }


### PR DESCRIPTION
# Description

Use base64 encoding for `FIREBASE_PRIVATE_KEY_B64` to avoid newline issues when uploading the private key to Render.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation
