### PR TITLE
fix: await fire-and-forget async calls and reject invalid seat rebinding

### DIFF
--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -568,11 +568,14 @@ async function playerLeaveRoom(
         // remove the game
         const myDeletedGame = await deleteGame(data.leaveRoomId);
         if (myDeletedGame) {
-            myDeletedGame.players.forEach(async (player) => {
-                const eachUid = myDeletedGame.playerToUidMap.get(player);
-                eachUid &&
-                    (await removeGame(eachUid, myDeletedGame._id.toString()));
-            });
+            await Promise.all(
+                myDeletedGame.players.map((player) => {
+                    const eachUid = myDeletedGame.playerToUidMap.get(player);
+                    return eachUid
+                        ? removeGame(eachUid, myDeletedGame._id.toString())
+                        : undefined;
+                }),
+            );
             io.sockets
                 .in(data.leaveRoomId)
                 .emit('youHaveLeftTheRoom', { ...data, players: [] });

--- a/src/routes/games/index.ts
+++ b/src/routes/games/index.ts
@@ -57,17 +57,29 @@ games.get('/:gameId', optionalAuth, async (req, res) => {
     res.status(200).send(sanitizeGameForClient(view));
 });
 
-// links the calling player's own verified uid to their seat in a game
+// links the calling player's own verified uid to their seat in a game -
+// playerName must be a real, still-unclaimed (or already-theirs) seat, so
+// one account can't overwrite another's existing binding just by naming
+// their seat here
 games.post('/:gameId/:playerName', requireAuth, async (req, res) => {
     const { gameId, playerName } = req.params;
     const myGame = await getGameById(gameId);
-    if (myGame) {
-        myGame.playerToUidMap.set(playerName, req.uid as string);
-        myGame.save();
-        res.status(200).send(sanitizeGameForClient(myGame));
-    } else {
+    if (!myGame) {
         res.status(404).send('Game not found');
+        return;
     }
+    if (!myGame.players.includes(playerName)) {
+        res.status(404).send('No such seat in this game.');
+        return;
+    }
+    const existingUid = myGame.playerToUidMap.get(playerName);
+    if (existingUid && existingUid !== req.uid) {
+        res.status(403).send('This seat is already claimed by another account.');
+        return;
+    }
+    myGame.playerToUidMap.set(playerName, req.uid as string);
+    await myGame.save();
+    res.status(200).send(sanitizeGameForClient(myGame));
 });
 
 export default games;

--- a/src/routes/user/index.ts
+++ b/src/routes/user/index.ts
@@ -53,8 +53,7 @@ user.get('/:userId', async (req, res) => {
     }
 });
 user.post('/:userId/games/:gameId', async (req, res) => {
-    addGame(req.params.userId, req.params.gameId);
-    const myUser = await getUser(req.params.userId);
+    const myUser = await addGame(req.params.userId, req.params.gameId);
     if (myUser) {
         res.status(200).send(myUser);
         console.info('sending user');


### PR DESCRIPTION
## Summary
- Three call sites dropped their promise: `addGame` in `POST /user/:userId/games/:gameId`, `Game.save()` in `POST /games/:gameId/:playerName`, and `removeGame` inside a `forEach` in `playerLeaveRoom`'s host-delete path. Each is now properly awaited.
- `POST /games/:gameId/:playerName` previously let any authenticated caller bind their uid to any `playerName` string, whether or not it was a real seat in that game, and even if the seat already belonged to someone else. It now rejects a `playerName` that isn't a real seat, or one already claimed by a different account.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint .`
- [x] `NODE_ENV=test npx jest` (135 passed)