### PR TITLE
feat: add CI/CD pipeline with staging-gated promotion to production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  lint-typecheck-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npx tsc --noEmit
+      - run: npm test

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,70 @@
+name: Promote to production
+
+# main is the staging trigger - Render auto-deploys luzhanqi-backend-staging
+# on every push here. This workflow waits for that deploy to go live, smoke
+# tests it, and only then fast-forwards `production` (the prod trigger) to
+# match - so prod only ever gets a commit that staging has already proven
+# out. See the pipeline plan for the full rationale.
+on:
+  push:
+    branches: [main]
+
+env:
+  STAGING_SERVICE_ID: srv-d9akgnlaeets73boftdg
+  STAGING_URL: https://luzhanqi-backend-staging.onrender.com
+
+jobs:
+  wait-and-smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for this commit's staging deploy to go live
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+        run: |
+          SHA="${{ github.sha }}"
+          for i in $(seq 1 60); do
+            STATUS=$(curl -s -H "Authorization: Bearer $RENDER_API_KEY" \
+              "https://api.render.com/v1/services/$STAGING_SERVICE_ID/deploys?limit=10" \
+              | jq -r --arg sha "$SHA" '[.[] | select(.commit.id == $sha)][0].status // "not-found"')
+            echo "Deploy status for $SHA: $STATUS"
+            if [ "$STATUS" = "live" ]; then
+              exit 0
+            fi
+            case "$STATUS" in
+              build_failed|update_failed|canceled|deactivated)
+                echo "Staging deploy did not succeed (status: $STATUS)."
+                exit 1
+                ;;
+            esac
+            sleep 10
+          done
+          echo "Timed out waiting for staging deploy to go live."
+          exit 1
+
+      - name: Smoke test staging
+        run: |
+          health_code=$(curl -s -o /dev/null -w '%{http_code}' "$STAGING_URL/health")
+          if [ "$health_code" != "200" ]; then
+            echo "GET /health returned $health_code, expected 200"
+            exit 1
+          fi
+
+          game_code=$(curl -s -o /dev/null -w '%{http_code}' "$STAGING_URL/games/000000000000000000000000")
+          if [ "$game_code" != "404" ]; then
+            echo "GET /games/<fake id> returned $game_code, expected 404"
+            exit 1
+          fi
+
+          echo "Staging smoke tests passed."
+
+  promote:
+    needs: wait-and-smoke-test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fast-forward production to this commit
+        run: git push origin HEAD:production

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "build": "tsc --p ./tsconfig.json -p .",
         "dev": "tsx watch --trace-deprecation ./src/server.ts",
         "prod": "NODE_ENV=production npm run start",
+        "lint": "eslint .",
         "test": "NODE_ENV=test jest",
         "prepare": "husky install"
     },

--- a/render.yaml
+++ b/render.yaml
@@ -3,8 +3,12 @@ services:
     name: luzhanqi-backend
     runtime: docker
     plan: free
-    branch: main
+    # prod deploys only from `production`, which the promote.yml workflow
+    # fast-forwards from `main` once staging passes its smoke test - never
+    # push directly to this branch
+    branch: production
     autoDeploy: true
+    healthCheckPath: /health
     envVars:
       - key: NODE_ENV
         value: production
@@ -15,8 +19,10 @@ services:
     name: luzhanqi-backend-staging
     runtime: docker
     plan: free
+    # staging deploys every merge to main - see promote.yml
     branch: main
     autoDeploy: true
+    healthCheckPath: /health
     envVars:
       - key: NODE_ENV
         value: production

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,6 +28,18 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, '../public')));
+
+// used by CI/CD promotion checks and Render's own health checks - reports
+// 503 while Mongo is unreachable rather than a false-positive 200, since a
+// disconnected DB makes every real route unusable anyway
+app.get('/health', (_req, res) => {
+    const mongoConnected = mongoose.connection.readyState === 1;
+    res.status(mongoConnected ? 200 : 503).send({
+        status: mongoConnected ? 'ok' : 'degraded',
+        mongo: mongoConnected ? 'connected' : 'disconnected',
+    });
+});
+
 app.use('/user', user);
 app.use('/games', game);
 


### PR DESCRIPTION
## Summary
- Adds `GET /health` (mongo connection status) for use by CI smoke tests and Render's own health checks.
- New `.github/workflows/ci.yml`: lint + typecheck + test, will become a required PR check on `main`.
- New `.github/workflows/promote.yml`: on push to `main`, waits for that commit's staging deploy to go live, smoke-tests `/health` and a 404 lookup, then fast-forwards `production` (which Render now deploys to prod) - so prod only ever gets a commit staging already proved out.
- `render.yaml` + the live Render services updated: `luzhanqi-backend` now tracks `production`, `luzhanqi-backend-staging` stays on `main`. Both now have `healthCheckPath: /health`.
- A `production` branch was pushed, currently identical to `main`'s tip - this PR does not change what's live in prod.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint .`
- [x] `NODE_ENV=test npx jest` (135 passed)
- [x] `docker compose up` locally, confirmed `GET /health` returns 200 and `GET /games/000000000000000000000000` returns 404
- [ ] After merge: confirm `ci.yml` and `promote.yml` both run and behave as expected against the real staging deploy