### PR TITLE
fix: correct Render deploy API response shape in promote workflow

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -25,7 +25,7 @@ jobs:
           for i in $(seq 1 60); do
             STATUS=$(curl -s -H "Authorization: Bearer $RENDER_API_KEY" \
               "https://api.render.com/v1/services/$STAGING_SERVICE_ID/deploys?limit=10" \
-              | jq -r --arg sha "$SHA" '[.[] | select(.commit.id == $sha)][0].status // "not-found"')
+              | jq -r --arg sha "$SHA" '[.[] | select(.deploy.commit.id == $sha)][0].deploy.status // "not-found"')
             echo "Deploy status for $SHA: $STATUS"
             if [ "$STATUS" = "live" ]; then
               exit 0


### PR DESCRIPTION
## Summary
The first real run of `promote.yml` (from merging #104) got stuck polling forever: Render's actual `GET /v1/services/:id/deploys` response wraps each entry as `{deploy: {...}, cursor: ...}`, not a bare deploy object like the `render` CLI displays. Verified against the live API directly and confirmed the fix (`.deploy.commit.id` / `.deploy.status`) matches a real response. That run was cancelled rather than left to time out.

## Test plan
- [x] Verified the corrected jq filter against a real captured Render API response shape
- [x] YAML parses cleanly
- [ ] After merge: confirm this run actually detects the staging deploy and promotes

https://claude.ai/code/session_01Fyz8mF7R2PrEvJyyNDJWVD