### PR TITLE
docs: document the new CI/CD pipeline and add CONTRIBUTORS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,12 @@ socket.io for realtime gameplay and MongoDB (Mongoose) for persistence.
 - `npm test` — Jest (`NODE_ENV=test jest`); tests are colocated as `*.test.ts` next to the source they cover
 - `docker compose up` — starts MongoDB + the app together (bind-mounts the repo, runs `npm run dev` inside the container); requires a `.env` file (see README.md for the template)
 
-Node 20.9.0. A pre-commit hook (husky + lint-staged) runs `eslint --fix` on
+Node 24.15.0. A pre-commit hook (husky + lint-staged) runs `eslint --fix` on
 `*.js` and `tsc-files --noEmit` (type-check only, no auto-fix) on `**/*.ts`.
-There is no CI configured for this repo — `tsc --noEmit` and `npm test` are
-the verification surface; DB-dependent changes additionally need a live
+CI (`.github/workflows/ci.yml`) runs `npm run lint`, `tsc --noEmit`, and
+`npm test` on every PR/push to `main`, and is a required status check — see
+"Deployment" below for what happens after a PR merges. There's still no
+DB-backed test infra, so DB-dependent changes additionally need a live
 `docker compose up` check (see gotchas below).
 
 ## Commit messages
@@ -22,6 +24,27 @@ the verification surface; DB-dependent changes additionally need a live
 Use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`,
 `fix:`, `refactor:`, `test:`, `docs:`, `chore:`, optionally with a scope,
 e.g. `fix(lzqgame): ...`).
+
+## Deployment
+
+`main` is the staging trigger; `production` is the prod trigger (the
+frontend repo follows the same model). The pipeline:
+
+1. A PR into `main` must pass `ci.yml` before it can merge (branch
+   protection).
+2. Merging to `main` auto-deploys `luzhanqi-backend-staging` on Render (see
+   `render.yaml`).
+3. `.github/workflows/promote.yml`, triggered by that same push, polls
+   Render until that commit's staging deploy is `live`, then smoke-tests
+   `GET /health` (expects 200) and `GET /games/<a well-formed but
+   nonexistent id>` (expects 404, proving the Express↔Mongoose round-trip
+   works). Only on success does it fast-forward `production` to match.
+4. Render auto-deploys `luzhanqi-backend` (prod) from `production`.
+
+**Never push directly to `production`** — it only ever advances via step 3,
+and a manual push would be silently overwritten (or diverge and break the
+fast-forward) on the next promotion. `GET /health` (`src/app.ts`) is also
+wired up as both services' Render `healthCheckPath`.
 
 ## Layout
 
@@ -122,6 +145,8 @@ invalid* one is treated as an error, not silently downgraded to anonymous.
   (`src/app.ts`'s `LOCAL_MONGO_URI`, a leftover from another project) — if
   inspecting the dev DB directly via `mongosh`, the database is
   `<DB_NAME>streamhatchet`, not `<DB_NAME>`.
-- Deploys to Render (see `render.yaml`) on the free tier — expect cold
-  starts (~30-60s) after ~15 min of inactivity. Firebase Admin credentials
-  are set as Render environment variables, not committed to the repo.
+- Render's free tier cold-starts (~30-60s) after ~15 min of inactivity —
+  affects both `luzhanqi-backend` and `luzhanqi-backend-staging`. Firebase
+  Admin credentials (`FIREBASE_PRIVATE_KEY_B64` etc) are set as Render
+  environment variables, not committed to the repo. See "Deployment" above
+  for the staging→production promotion flow.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,38 @@
+# Contributing to luzhanqi-backend
+
+## Workflow
+
+1. Branch off `main` (`type/short-description`, e.g. `fix/reconnect-token`,
+   `feat/rule-variant`, `chore/dep-bump`, `docs/...`).
+2. Open a PR into `main`. CI (`.github/workflows/ci.yml`: lint, typecheck,
+   `npm test`) must pass — it's a required status check, so the merge
+   button stays disabled until it's green.
+3. Use [Conventional Commits](https://www.conventionalcommits.org/)
+   (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`, optionally
+   with a scope) for commit messages and PR titles.
+4. Merge (this repo uses merge commits, not squash/rebase, so `git log`
+   keeps a per-PR merge commit).
+
+That's it from a contributor's side — everything after merge is automatic.
+See `AGENTS.md`'s "Deployment" section for what happens next (staging
+deploy → automated smoke test → promotion to production), and never push
+directly to the `production` branch, which only the promotion workflow
+should touch.
+
+## Local development
+
+- `docker compose up` — MongoDB + the app together, bind-mounted so edits
+  take effect via `npm run dev`'s auto-restart. See `README.md` for the
+  required `.env`.
+- `npm test` — Jest; there's no DB-backed test infra, so anything touching
+  `controllers/`/`services/gameplayService.ts`'s DB-facing functions needs
+  manual verification against a real `docker compose up` instance, not just
+  `npm test`.
+- `npx tsc --noEmit` / `npm run lint` — same checks CI runs, useful to run
+  locally before pushing.
+
+## Getting oriented
+
+Start with `AGENTS.md` — it covers the codebase layout, the
+authentication/authorization model, and known gotchas worth reading before
+touching game logic, auth, or rule variants.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,11 +13,26 @@
 4. Merge (this repo uses merge commits, not squash/rebase, so `git log`
    keeps a per-PR merge commit).
 
-That's it from a contributor's side — everything after merge is automatic.
-See `AGENTS.md`'s "Deployment" section for what happens next (staging
-deploy → automated smoke test → promotion to production), and never push
-directly to the `production` branch, which only the promotion workflow
-should touch.
+That's it from a contributor's side — everything after merge is automatic:
+
+```mermaid
+flowchart TD
+    A[PR opened against main] --> B{ci.yml\nlint + typecheck + test}
+    B -- fail --> A
+    B -- pass, merged --> C[main updated]
+    C --> D[Render auto-deploys\nluzhanqi-backend-staging]
+    D --> E{promote.yml\npoll staging deploy, then smoke test}
+    E -- fail --> F[Stops here\nproduction untouched]
+    E -- pass --> G[Fast-forward production\nto match main]
+    G --> H[Render auto-deploys\nluzhanqi-backend prod]
+```
+
+`main` is the staging trigger, `production` is the prod trigger — never
+push directly to `production`, since only `promote.yml`'s fast-forward
+should ever move it. The smoke test hits `GET /health` (expects 200) and
+`GET /games/<a well-formed but nonexistent id>` (expects 404, proving the
+Express↔Mongoose round-trip works) against staging before promoting; if
+either fails, prod simply stays on its last good commit.
 
 ## Local development
 
@@ -33,6 +48,24 @@ should touch.
 
 ## Getting oriented
 
-Start with `AGENTS.md` — it covers the codebase layout, the
-authentication/authorization model, and known gotchas worth reading before
-touching game logic, auth, or rule variants.
+- `src/server.ts` — HTTP + socket.io bootstrap, CORS allowlist.
+- `src/lzqgame.ts` — all socket.io event handlers (join/rejoin/move/setup/
+  AI turns); also owns the auth/ownership checks for socket events.
+- `src/services/gameplayService.ts` — socket-free move/setup application
+  (`applyMove`, `submitInitialBoard`, `pieceMovement`) reused by both real
+  players and the AI's own turns. Prefer adding new gameplay logic here
+  over `lzqgame.ts` so it stays testable without a socket.
+- `src/controllers/` — Mongoose DB access (`gameController.ts`,
+  `userController.ts`).
+- `src/utils/` — pure, socket/DB-free functions: board/piece primitives,
+  move generation (`getSuccessors.ts`), setup validation, fog-of-war
+  redaction, the AI opponent.
+- The client sends a Firebase ID token (never a raw uid) wherever caller
+  identity matters; the server verifies it before trusting anything.
+  Anonymous play is allowed — a missing token is fine, a *present but
+  invalid* one is treated as an error, never silently downgraded to
+  anonymous.
+- A rule-variant change must stay in sync across `pieceMovement`/
+  `getSuccessors.ts` (server truth), `aiPlayer.ts` (so the AI doesn't
+  misjudge outcomes under a variant it doesn't know about), and the
+  frontend's `predictOutcome.js`/`getSuccessors.js` mirrors.

--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ anonymous play works fine but any request carrying a real auth token fails.
 
 Merging a PR into `main` deploys to staging, then a GitHub Actions workflow
 smoke-tests it and — if it passes — promotes it to production
-automatically. See `AGENTS.md`'s "Deployment" section for the full flow,
-and `CONTRIBUTORS.md` for the contribution workflow.
+automatically. See `CONTRIBUTORS.md` for the full flow (including a
+diagram) and the contribution workflow.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,25 @@ EOF
 
 Install docker and docker-compose. Then run
 
+Optionally, if you need to test real (non-anonymous) sign-in locally, also
+add `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, and
+`FIREBASE_PRIVATE_KEY_B64` (base64-encoded service account private key) to
+`.env` — ask a team member for a service account key. Without these,
+anonymous play works fine but any request carrying a real auth token fails.
+
 ## Starting the server
 
 `git clone` to copy repository files into your local.  
-`docker-compose up``
+`docker-compose up`
+
+## Deployment
+
+- **Production**: https://luzhanqi-backend.onrender.com (Render, deploys
+  from the `production` branch)
+- **Staging**: https://luzhanqi-backend-staging.onrender.com (Render,
+  deploys from `main`)
+
+Merging a PR into `main` deploys to staging, then a GitHub Actions workflow
+smoke-tests it and — if it passes — promotes it to production
+automatically. See `AGENTS.md`'s "Deployment" section for the full flow,
+and `CONTRIBUTORS.md` for the contribution workflow.


### PR DESCRIPTION
## Summary
- `AGENTS.md` had two stale claims (Node 20.9.0, "no CI configured") - fixed, and added a "Deployment" section describing the main=staging/production=prod promotion flow.
- `README.md`: added deploy URLs and the optional Firebase env vars needed to test real (non-anonymous) sign-in locally.
- New `CONTRIBUTORS.md`: branch naming, PR/CI requirements, commit message convention, local dev pointers.