### PR TITLE
fix: a bomb hitting the flag under captureTheFlag destroys only the bomb

### DIFF
--- a/src/controllers/gameController.ts
+++ b/src/controllers/gameController.ts
@@ -468,8 +468,10 @@ export const updateGame = async (
 /**
  * Pure win-check for the captureTheFlag rule variant, extracted from
  * winner() so it's testable without a database. A carrier wins by reaching
- * its own home HQ row; a flag destroyed outright (e.g. by a bomb) with no
- * one carrying it falls back to an instant loss for its owner.
+ * its own home HQ row; a flag destroyed outright with no one carrying it
+ * (not reachable in normal play - a bomb attacking the flag only destroys
+ * itself, see pieceMovement - but kept as a defensive fallback) falls back
+ * to an instant loss for its owner.
  * @see winnerUnderCaptureTheFlag
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -502,9 +504,9 @@ export function winnerUnderCaptureTheFlag(myBoard: any): number {
         return winnerIndex;
     }
 
-    // a flag can still be destroyed outright (e.g. by a bomb) without ever
-    // being carried - if so, fall back to the simple-capture rule (missing
-    // flag with no one carrying it is an instant loss for its owner)
+    // defensive fallback: if a flag were ever destroyed outright without
+    // being carried, treat it as an instant loss for its owner, same as
+    // the simple-capture rule
     for (let affiliation = 0; affiliation < 2; affiliation += 1) {
         if (flagsPresent[affiliation]) {
             // eslint-disable-next-line no-continue

--- a/src/services/gameplayService.test.ts
+++ b/src/services/gameplayService.test.ts
@@ -320,6 +320,47 @@ describe('pieceMovement', () => {
             });
             expect(newBoard[0][1]?.carryingFlag).toBeUndefined();
         });
+
+        test('a bomb attacking the flag destroys only the bomb - the flag survives uncaptured', () => {
+            let board = emptyBoard();
+            board = placePiece(board, 1, 1, createPiece('bomb', 0));
+            board = placePiece(board, 0, 1, createPiece('flag', 1));
+
+            const { board: newBoard, deadPieces } = pieceMovement(
+                board,
+                [1, 1],
+                [0, 1],
+                {
+                    captureTheFlag: true,
+                },
+            );
+
+            expect(deadPieces).toEqual([
+                expect.objectContaining({ name: 'bomb', affiliation: 0 }),
+            ]);
+            expect(newBoard[1][1]).toBeNull();
+            expect(newBoard[0][1]).toMatchObject({
+                name: 'flag',
+                affiliation: 1,
+            });
+            expect(newBoard[0][1]?.carryingFlag).toBeUndefined();
+        });
+
+        test('without captureTheFlag, a bomb attacking the flag still destroys both (default behavior unchanged)', () => {
+            let board = emptyBoard();
+            board = placePiece(board, 1, 1, createPiece('bomb', 0));
+            board = placePiece(board, 0, 1, createPiece('flag', 1));
+
+            const { board: newBoard, deadPieces } = pieceMovement(
+                board,
+                [1, 1],
+                [0, 1],
+            );
+
+            expect(deadPieces).toHaveLength(2);
+            expect(newBoard[1][1]).toBeNull();
+            expect(newBoard[0][1]).toBeNull();
+        });
     });
 
     test('an out-of-range coordinate is a no-op, not a thrown error', () => {

--- a/src/services/gameplayService.ts
+++ b/src/services/gameplayService.ts
@@ -131,6 +131,19 @@ export function pieceMovement(
             board[source[0]][source[1]] = null;
         }
     } else if (
+        config.captureTheFlag &&
+        targetPiece &&
+        targetPiece.name === 'flag' &&
+        sourcePiece.name === 'bomb'
+    ) {
+        // under captureTheFlag, the flag is an objective to be carried
+        // home, not something any attacker can simply blow up - unlike
+        // every other matchup, a bomb hitting the flag only destroys
+        // itself, leaving the flag in place for a later piece to actually
+        // capture (and carry)
+        deadPieces.push(sourcePiece);
+        board[source[0]][source[1]] = null;
+    } else if (
         targetPiece &&
         (sourcePiece.name === 'bomb' ||
             sourcePiece.name === targetPiece.name ||
@@ -167,9 +180,11 @@ export function pieceMovement(
     // instead, rather than ending the game or disappearing forever. The
     // source tile of this move is always empty afterward whenever a piece
     // died (every combat branch above vacates it), so it's always a valid
-    // last-resort drop spot. This guarantees the flag can only ever
-    // disappear from the board outright (ending the game per winner()'s
-    // fallback) by being destroyed before anyone has captured it.
+    // last-resort drop spot. Since a bomb attacking the flag now only
+    // destroys itself (see above), the flag can no longer be destroyed
+    // outright before ever being captured under this variant -
+    // winnerUnderCaptureTheFlag's fallback for that case is purely
+    // defensive at this point.
     if (config.captureTheFlag) {
         deadPieces
             .filter((piece) => piece.carryingFlag)


### PR DESCRIPTION
## Summary
Under `captureTheFlag`, a bomb attacking the flag previously fell into the generic mutual-destruction rule (same as attacking any other piece), destroying the flag outright and ending the game instantly via `winnerUnderCaptureTheFlag`'s fallback. That defeats the point of the variant - the flag is supposed to be an objective a piece captures and carries home, not something that can just be blown up.

Now, under `captureTheFlag` specifically, a bomb attacking the flag only destroys itself; the flag survives uncaptured for a later piece to actually capture. Base-ruleset behavior (`captureTheFlag` off) is unchanged - there, the game already ends the instant the flag disappears regardless of which piece(s) died, so there was nothing to fix.

Also updated the now-inaccurate "flag destroyed outright by a bomb" comments in `winnerUnderCaptureTheFlag` - that fallback is purely defensive now.

## Test plan
- [x] New tests: bomb-vs-flag under `captureTheFlag` (bomb dies, flag survives uncaptured) and without it (both die, unchanged)
- [x] `npx tsc --noEmit`, `npm run lint`, `npm test` (137 passed)