### PR TITLE
fix: resolve npm audit vulnerabilities (micromatch, uuid)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8694,12 +8694,13 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -11709,10 +11710,9 @@
             }
         },
         "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
@@ -11720,7 +11720,7 @@
             "license": "MIT",
             "optional": true,
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
         "bufferutil": "^4.0.2",
         "utf-8-validate": "^5.0.3"
     },
+    "overrides": {
+        "uuid": "^11.1.1"
+    },
     "lint-staged": {
         "*.js": "eslint --cache --fix",
         "**/*.ts": "tsc-files --noEmit"


### PR DESCRIPTION
## Summary
`npm audit` reported 7 moderate vulnerabilities:
- **micromatch** (transitive via jest, dev-only): fixed by plain `npm audit fix`, no breaking change.
- **uuid** (transitive via `firebase-admin` -> `@google-cloud/storage`'s `gaxios`/`teeny-request`, used only for Cloud Storage's own internals - not anything this app calls): npm's suggested fix downgrades `firebase-admin` 14.2.0 -> 10.3.0, not worth it for a moderate issue in an unused code path. Added a package.json `overrides` entry pinning `uuid` to `^11.1.1` across every transitive resolution instead, keeping `firebase-admin` at 14.2.0.

`npm audit`: 0 vulnerabilities (was 7 moderate).

## Test plan
- [x] `npm ls uuid` confirms `firebase-admin@14.2.0` unchanged, `uuid@11.1.1` resolved everywhere
- [x] `npx tsc --noEmit`, `npm run lint`, `npm test` (137 passed)
- [x] `npm audit` clean