### PR TITLE
fix: missing rate limiting and workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint-typecheck-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   STAGING_SERVICE_ID: srv-d9akgnlaeets73boftdg
   STAGING_URL: https://luzhanqi-backend-staging.onrender.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "debug": "~2.6.9",
                 "dotenv": "^17.4.2",
                 "express": "^4.16.4",
+                "express-rate-limit": "^8.6.0",
                 "firebase-admin": "^14.2.0",
                 "lodash": "^4.17.21",
                 "lodash.isequal": "^4.5.0",
@@ -5655,6 +5656,48 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/express-rate-limit": {
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+            "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "ip-address": "^10.2.0"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": ">= 4.11"
+            }
+        },
+        "node_modules/express-rate-limit/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/express-rate-limit/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
         "node_modules/extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -6989,6 +7032,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/ip-address": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/ipaddr.js": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "debug": "~2.6.9",
         "dotenv": "^17.4.2",
         "express": "^4.16.4",
+        "express-rate-limit": "^8.6.0",
         "firebase-admin": "^14.2.0",
         "lodash": "^4.17.21",
         "lodash.isequal": "^4.5.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import logger from 'morgan';
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import user from './routes/user';
 import game from './routes/games';
 import cors from 'cors';
@@ -40,7 +41,17 @@ app.get('/health', (_req, res) => {
     });
 });
 
-app.use('/user', user);
-app.use('/games', game);
+// gameplay itself goes over socket.io (lzqgame.ts), not these REST routes -
+// they're only hit for account/history operations, so a generous per-IP
+// window is plenty to stop abuse without affecting real usage
+const apiLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    limit: 100,
+    standardHeaders: true,
+    legacyHeaders: false,
+});
+
+app.use('/user', apiLimiter, user);
+app.use('/games', apiLimiter, game);
 
 export default app;

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ import logger from 'morgan';
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
 import express from 'express';
-import rateLimit from 'express-rate-limit';
+import rateLimit, { MINUTE } from 'express-rate-limit';
 import user from './routes/user';
 import game from './routes/games';
 import cors from 'cors';
@@ -45,9 +45,14 @@ app.get('/health', (_req, res) => {
 // they're only hit for account/history operations, so a generous per-IP
 // window is plenty to stop abuse without affecting real usage
 const apiLimiter = rateLimit({
-    windowMs: 15 * 60 * 1000,
+    windowMs: 15 * MINUTE,
     limit: 100,
+    // RateLimit-* headers (IETF draft standard) - the modern replacement
+    // for the X-RateLimit-* headers below; safe for any client to read
     standardHeaders: true,
+    // X-RateLimit-* headers - older de facto convention some clients/
+    // proxies still expect; off since nothing here depends on them and
+    // sending both is redundant
     legacyHeaders: false,
 });
 


### PR DESCRIPTION
## Summary
- Add `express-rate-limit` (100 req/15min per IP) to `/user` and `/games`, the only REST routes CodeQL flagged (`js/missing-rate-limiting`, high x3). Actual gameplay goes over socket.io, not these routes, so a generous per-IP window is plenty to stop abuse without affecting real usage. `/health` is deliberately excluded (hit constantly by the CI/CD promote workflow and Render's own health checks, does nothing expensive).
- Add explicit least-privilege `permissions:` to both GitHub Actions workflows (`actions/missing-workflow-permissions`, medium x2) - same fix as chinese-board-games/luzhanqi-web#185.

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint`, `npm test` (137 passed)
- [x] Rebuilt and ran the real docker compose stack, hammered `GET /games/000000000000000000000000` 101 times, confirmed the 101st request returns 429 with the expected `RateLimit-*` headers