### PR TITLE
fix: player loses when no legal moves remain on their turn

### DIFF
--- a/src/controllers/gameController.test.ts
+++ b/src/controllers/gameController.test.ts
@@ -174,7 +174,8 @@ describe('winner (default, non-captureTheFlag rules)', () => {
     // filler pieces in the rows ahead of each flag so a scan actually
     // encounters other pieces first, the same as a real, mostly-full
     // game board would.
-    const asPreloadedGame = (board: unknown) => ({ board, config: {} } as any);
+    const asPreloadedGame = (board: unknown, extra: Record<string, unknown> = {}) =>
+        ({ board, config: {}, ...extra } as any);
 
     test('no winner while both flags are present, several rows deep in their own half', async () => {
         let board = emptyBoard();
@@ -204,5 +205,48 @@ describe('winner (default, non-captureTheFlag rules)', () => {
         board = placePiece(board, 7, 0, createPiece('captain', 0));
 
         expect(await winner('unused', asPreloadedGame(board))).toBe(1);
+    });
+
+    // regression coverage for chinese-board-games/luzhanqi-backend#111: a
+    // player down to only immobile pieces (or otherwise boxed in) on their
+    // own turn was never declared the loser - the game just stalled,
+    // forcing a manual forfeit. runAiTurn already special-cased this for
+    // the AI; these confirm winner() now catches it generically, for both
+    // human players and the AI.
+    test('the guest loses on their own turn once only immobile pieces remain, even with both flags present', async () => {
+        let board = emptyBoard();
+        board = placePiece(board, 8, 1, createPiece('flag', 0));
+        board = placePiece(board, 7, 0, createPiece('captain', 0));
+        board = placePiece(board, 3, 3, createPiece('flag', 1));
+        board = placePiece(board, 2, 1, createPiece('landmine', 1));
+
+        // turn 1 -> turn % 2 === 1 -> it's the guest's (affiliation 1) turn
+        expect(await winner('unused', asPreloadedGame(board, { turn: 1 }))).toBe(0);
+    });
+
+    test('is not decided by stalemate when it is the other player\'s turn', async () => {
+        let board = emptyBoard();
+        board = placePiece(board, 8, 1, createPiece('flag', 0));
+        board = placePiece(board, 7, 0, createPiece('captain', 0));
+        board = placePiece(board, 3, 3, createPiece('flag', 1));
+        board = placePiece(board, 2, 1, createPiece('landmine', 1));
+
+        // turn 0 -> it's the host's turn, and the host (who still has a
+        // mobile captain) is not the one who's stuck
+        expect(await winner('unused', asPreloadedGame(board, { turn: 0 }))).toBe(-1);
+    });
+
+    test('stalemate applies under the captureTheFlag variant too', async () => {
+        let board = emptyBoard();
+        board = placePiece(board, 8, 1, createPiece('flag', 0));
+        board = placePiece(board, 7, 0, createPiece('captain', 0));
+        board = placePiece(board, 3, 3, createPiece('flag', 1));
+        board = placePiece(board, 2, 1, createPiece('landmine', 1));
+
+        const game = asPreloadedGame(board, {
+            turn: 1,
+            config: { captureTheFlag: true },
+        });
+        expect(await winner('unused', game)).toBe(0);
     });
 });

--- a/src/controllers/gameController.ts
+++ b/src/controllers/gameController.ts
@@ -5,6 +5,7 @@ import {
     AI_SOCKET_SENTINEL,
     DEFAULT_AI_WEIGHTS,
 } from '../utils/aiConstants';
+import { hasLegalMoves } from '../utils/getSuccessors';
 
 /**
  * generates an opaque random token used to prove ownership of a player's
@@ -527,6 +528,17 @@ export function winnerUnderCaptureTheFlag(myBoard: any): number {
     return -1;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const winnerByStalemate = (myBoard: any, myGame: PreloadedGame): number => {
+    // whoever's turn is next - the same player runAiTurn checks before an
+    // AI move; this covers the human-vs-human case that gap left open
+    const toMove = (myGame?.turn ?? 0) % 2;
+    if (hasLegalMoves(myBoard, toMove, { flyingBombs: myGame?.config?.flyingBombs })) {
+        return -1;
+    }
+    return 1 - toMove;
+};
+
 export const winner = async (gid: string, preloadedGame?: PreloadedGame) => {
     const myGame = preloadedGame ?? (await getGameById(gid));
     if (!myGame) {
@@ -535,7 +547,10 @@ export const winner = async (gid: string, preloadedGame?: PreloadedGame) => {
     const myBoard = (await myGame.board) as any;
 
     if (myGame.config?.captureTheFlag) {
-        return winnerUnderCaptureTheFlag(myBoard);
+        const captureTheFlagWinner = winnerUnderCaptureTheFlag(myBoard);
+        return captureTheFlagWinner !== -1
+            ? captureTheFlagWinner
+            : winnerByStalemate(myBoard, myGame);
     }
 
     // a flag can legally sit on any row of its owner's half, so this counts
@@ -558,5 +573,5 @@ export const winner = async (gid: string, preloadedGame?: PreloadedGame) => {
         console.info('bottom half loses');
         return 1;
     }
-    return -1;
+    return winnerByStalemate(myBoard, myGame);
 };

--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -959,9 +959,12 @@ async function runAiTurn(gid: string, turn: number) {
     );
 
     if (!move) {
-        // AI has no legal moves - treat it as a forfeit (a pre-existing gap
-        // in winner() means human-vs-human stalemates aren't handled either,
-        // this just makes the case reachable and resolves it the same way)
+        // Belt-and-suspenders: winner()'s own stalemate check (see
+        // gameController.winnerByStalemate) already ends the game the
+        // moment the preceding move leaves the AI with no legal moves, so
+        // scheduleAiTurn - and therefore this branch - shouldn't normally
+        // fire at all. Kept as a defensive fallback in case that check and
+        // chooseAiMove's own legal-move search ever disagree.
         const winnerIndex = aiPlayerIndex === 0 ? 1 : 0;
         const gameStats = await getGameStats(gid);
         await updateGame(gid, {

--- a/src/utils/getSuccessors.test.ts
+++ b/src/utils/getSuccessors.test.ts
@@ -7,6 +7,7 @@ import {
     _getEngineerRailroadMoves,
     _getNormalRailroadMoves,
     isBlockedPath,
+    hasLegalMoves,
 } from './getSuccessors';
 
 import { createPiece, placePiece } from './piece';
@@ -368,5 +369,54 @@ describe('getSuccessors', () => {
             );
             expect(withFlyingBombs).toEqual(without);
         });
+    });
+});
+
+describe('hasLegalMoves', () => {
+    let board = emptyBoard();
+
+    beforeEach(() => {
+        board = emptyBoard();
+    });
+
+    test('true when a piece has an open square to move to', () => {
+        board = placePiece(board, 6, 0, createPiece('captain', 0));
+        expect(hasLegalMoves(board, 0)).toBe(true);
+    });
+
+    test('false when the affiliation only has immobile pieces left (flag/landmines)', () => {
+        board = placePiece(board, 11, 1, createPiece('flag', 0));
+        board = placePiece(board, 10, 1, createPiece('landmine', 0));
+        board = placePiece(board, 10, 3, createPiece('landmine', 0));
+        // the opponent still has real pieces, which must not affect this check
+        board = placePiece(board, 0, 0, createPiece('captain', 1));
+
+        expect(hasLegalMoves(board, 0)).toBe(false);
+        expect(hasLegalMoves(board, 1)).toBe(true);
+    });
+
+    test('false when a lone mobile piece is fully boxed in by its own (immobile) pieces', () => {
+        // [0, 0] is a corner tile - neither a camp (no diagonals) nor a
+        // railroad - so its only adjacency is [1, 0] and [0, 1]. Both are
+        // occupied here by friendly landmines, which block the captain
+        // (can't move onto your own piece) while contributing no moves of
+        // their own (landmines never move) - so the whole affiliation is
+        // stuck, not just the captain.
+        board = placePiece(board, 0, 0, createPiece('captain', 0));
+        board = placePiece(board, 1, 0, createPiece('landmine', 0));
+        board = placePiece(board, 0, 1, createPiece('landmine', 0));
+
+        expect(getSuccessors(board, 0, 0, 0)).toEqual([]);
+        expect(hasLegalMoves(board, 0)).toBe(false);
+    });
+
+    test('attacking an enemy piece still counts as a legal move', () => {
+        // same box as above, but the blockers are enemy pieces instead of
+        // friendly ones - moving onto them is a legal attack
+        board = placePiece(board, 0, 0, createPiece('captain', 0));
+        board = placePiece(board, 1, 0, createPiece('lieutenant', 1));
+        board = placePiece(board, 0, 1, createPiece('lieutenant', 1));
+
+        expect(hasLegalMoves(board, 0)).toBe(true);
     });
 });

--- a/src/utils/getSuccessors.ts
+++ b/src/utils/getSuccessors.ts
@@ -293,6 +293,33 @@ export function getSuccessors(
     return allMoves;
 }
 
+/**
+ * Whether the given affiliation has at least one legal move available on
+ * the current board - i.e. some non-landmine, non-flag piece of theirs has
+ * a non-empty getSuccessors() result. A player with none (all remaining
+ * pieces immobile, or fully boxed in) has no move to make on their turn,
+ * which should end the game rather than stall it waiting for a manual
+ * forfeit.
+ * @see getSuccessors
+ */
+export function hasLegalMoves(
+    board: Board,
+    affiliation: number,
+    config: { flyingBombs?: boolean } = {},
+): boolean {
+    for (let r = 0; r < board.length; r += 1) {
+        for (let c = 0; c < board[r].length; c += 1) {
+            if (board[r][c]?.affiliation !== affiliation) {
+                continue;
+            }
+            if (getSuccessors(board, r, c, affiliation, config).length > 0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 export function isBlockedPath(origin: number[], destination: number[]) {
     const blockedPaths = [
         { origin: [5, 1], destination: [6, 1] },


### PR DESCRIPTION
## Summary
- `winner()` only ever checked flag capture, so a player reduced to immobile pieces (or otherwise fully boxed in) never actually lost — the game just stalled until someone manually forfeited
- This was already special-cased for the AI (`runAiTurn`'s `!move` branch), whose comment even flagged the human-vs-human gap this closes
- Adds `hasLegalMoves(board, affiliation, config)` to `getSuccessors.ts`, and a `winnerByStalemate()` check in `gameController.winner()` that fires whenever the flag-based check is inconclusive: if the player whose turn is next has zero legal moves, they lose
- Runs generically for both the `captureTheFlag` and default rule variants, and for both human and AI turns, since it's driven by the same `applyMove` → `winner` path both already go through
- No frontend changes needed — `endGame` already carries a plain `winnerIndex`/`gameStats`/`finalGame` payload regardless of why the game ended (flag capture, forfeit, and now stalemate all look the same to the client)

Fixes #111

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npx jest` — 144/144 passing (7 new: `hasLegalMoves` unit tests + `winner()` stalemate integration tests, including a case confirming attacking an enemy piece still counts as a legal move, and a case confirming the stalemate check only fires on the stuck player's own turn)