### PR TITLE
fix(deps): bump js-yaml to 3.15.1 to clear GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8176,9 +8176,9 @@
             "dev": true
         },
         "node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
Closes Dependabot alert #78.

## Problem

`js-yaml@3.15.0` is vulnerable to quadratic CPU consumption while resolving `!!omap` — [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj), high severity, vulnerable range `>= 3.0.0, < 3.15.1`.

It reached the tree by two paths, **both development-only**:

```
eslint@7.32.0 → js-yaml@3.15.0          (and via @eslint/eslintrc@0.4.3)
jest@29.7.0 → … → babel-plugin-istanbul → @istanbuljs/load-nyc-config → js-yaml@3.15.0
```

No runtime code path parses YAML, so the deployed server on Render was never exposed. This was a lint/test-time exposure only.

## Fix

`3.15.1` is published on the `v3-legacy` dist-tag and satisfies the `^3.13.1` range both dependents declare, so `npm update js-yaml` resolves it without a manifest change or any major upgrade. The diff is 3 lines of `package-lock.json`.

Deliberately avoided the alternatives — an `overrides` entry isn't needed since the patch is already in range, and upgrading eslint 7 → 9 would be a much larger change for an unrelated reason.

## Testing

- `npm audit` → 0 vulnerabilities (was 1 high)
- `npm test` → 10 suites, 144 tests, all passing
- `npm ls js-yaml --all` confirms every path now resolves to 3.15.1