### PR TITLE
fix(fog): reveal the final board when the AI has no legal moves

### DIFF
--- a/src/lzqgame.test.ts
+++ b/src/lzqgame.test.ts
@@ -1,4 +1,4 @@
-import { formatGameStats } from './lzqgame';
+import { buildEndGamePayload, formatGameStats } from './lzqgame';
 import { GameStats } from './services/gameplayService';
 
 describe('formatGameStats', () => {
@@ -29,5 +29,37 @@ describe('formatGameStats', () => {
     test('handles a null gameStats without throwing', () => {
         expect(() => formatGameStats(null)).not.toThrow();
         expect(formatGameStats(null)).toBe('null');
+    });
+});
+
+describe('buildEndGamePayload', () => {
+    const board = [[{ name: 'flag', affiliation: 0 }]];
+    const game = {
+        board,
+        players: ['human', 'Computer'],
+        phase: 3,
+        playerToTokenMap: new Map([['human', 'secret-token']]),
+        playerToUidMap: new Map([['human', 'uid-1']]),
+        playerToSocketIdMap: new Map([['human', 'socket-1']]),
+    };
+
+    // the client only reveals the board when finalGame is present (see
+    // GameContext's endGame handler), so every ending has to carry it -
+    // including an AI left with no legal moves, which reaches the client
+    // as the computer giving up
+    test('carries the final board so the client can reveal it', () => {
+        const payload = buildEndGamePayload(0, null, game);
+
+        expect(payload.finalGame).toBeDefined();
+        expect(payload.finalGame.board).toEqual(board);
+        expect(payload.winnerIndex).toBe(0);
+    });
+
+    test('strips the credential maps from the revealed game', () => {
+        const payload = buildEndGamePayload(1, null, game);
+
+        expect(payload.finalGame).not.toHaveProperty('playerToTokenMap');
+        expect(payload.finalGame).not.toHaveProperty('playerToUidMap');
+        expect(payload.finalGame).not.toHaveProperty('playerToSocketIdMap');
     });
 });

--- a/src/lzqgame.ts
+++ b/src/lzqgame.ts
@@ -48,6 +48,25 @@ const socketSeatRegistry = new Map<string, { gid: string; playerName: string }>(
 export const formatGameStats = (gameStats: GameStats | null) =>
     inspect(gameStats, { depth: null });
 
+/**
+ * Builds the payload every game-ending broadcast carries. finalGame is the
+ * unfogged board the client reveals once the game is over (see GameContext's
+ * endGame handler, which only reveals when finalGame is present), so every
+ * ending is constructed here rather than inline - a new way for a game to end
+ * gets the reveal by construction instead of by remembering.
+ * @see buildEndGamePayload
+ */
+export const buildEndGamePayload = (
+    winnerIndex: number,
+    gameStats: GameStats | null,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    game: any,
+) => ({
+    winnerIndex,
+    gameStats,
+    finalGame: sanitizeGameForClient(game),
+});
+
 export const initGame = (sio: Server, socket: Socket) => {
     io = sio;
     gameSocket = socket;
@@ -892,11 +911,12 @@ async function playerMakeMove(
 
     if (result.winnerIndex !== -1) {
         console.info('game ended from victory', formatGameStats(result.gameStats));
-        io.sockets.in(gid).emit('endGame', {
-            winnerIndex: result.winnerIndex,
-            gameStats: result.gameStats,
-            finalGame: sanitizeGameForClient(result.game),
-        });
+        io.sockets
+            .in(gid)
+            .emit(
+                'endGame',
+                buildEndGamePayload(result.winnerIndex, result.gameStats, result.game),
+            );
         return;
     }
 
@@ -973,7 +993,9 @@ async function runAiTurn(gid: string, turn: number) {
                 'anonymous',
             phase: 3,
         });
-        io.sockets.in(gid).emit('endGame', { winnerIndex, gameStats });
+        io.sockets
+            .in(gid)
+            .emit('endGame', buildEndGamePayload(winnerIndex, gameStats, myGame));
         return;
     }
 
@@ -990,11 +1012,12 @@ async function runAiTurn(gid: string, turn: number) {
     broadcastFieldMarshallDown(gid, result.fieldMarshallDown);
     if (result.winnerIndex !== -1) {
         console.info('game ended from victory (AI)', formatGameStats(result.gameStats));
-        io.sockets.in(gid).emit('endGame', {
-            winnerIndex: result.winnerIndex,
-            gameStats: result.gameStats,
-            finalGame: sanitizeGameForClient(result.game),
-        });
+        io.sockets
+            .in(gid)
+            .emit(
+                'endGame',
+                buildEndGamePayload(result.winnerIndex, result.gameStats, result.game),
+            );
     }
 }
 
@@ -1022,16 +1045,11 @@ async function playerForfeit(
 
     const gameStats = await getGameStats(gid);
     console.info('game ended due to forfeit');
-    // unfogged, same as the other endGame emits - the client relies on
-    // finalGame to reveal the board once the game is over (see
-    // GameContext.jsx's endGame handler); the board itself is unaffected by
-    // a forfeit, so myGame (fetched before the phase update above) is still
-    // accurate
-    io.sockets.in(gid).emit('endGame', {
-        winnerIndex,
-        gameStats,
-        finalGame: sanitizeGameForClient(myGame),
-    });
+    // a forfeit leaves the board itself untouched, so myGame - fetched before
+    // the phase update above - is still an accurate final board
+    io.sockets
+        .in(gid)
+        .emit('endGame', buildEndGamePayload(winnerIndex, gameStats, myGame));
 }
 
 /**


### PR DESCRIPTION
Closes https://github.com/chinese-board-games/luzhanqi-web/issues/187.

## Problem

The client only reveals the board at game over when the `endGame` payload carries `finalGame` — the handler in `GameContext.jsx` is guarded:

```js
socket.on('endGame', ({ winnerIndex, gameStats, finalGame }) => {
  ...
  if (finalGame) {
    setMyBoard(finalGame.board);
  }
});
```

There are four game-ending broadcasts in `lzqgame.ts`. Three sent `finalGame`. The fourth — an AI left with no legal moves, which reaches the player as the computer giving up — sent only `winnerIndex` and `gameStats`:

```js
io.sockets.in(gid).emit('endGame', { winnerIndex, gameStats });
```

So that one summary screen kept the fogged board and never revealed the opponent's pieces.

This is the same defect #77 fixed for forfeits. That commit's message notes `playerForfeit`'s emit "omitted `finalGame` entirely (unlike the other two endGame emit sites)" — it counted three sites and fixed one, leaving this fourth untouched.

## Fix

Rather than adding the missing field to one more call site, the payload is now built in one place:

```js
export const buildEndGamePayload = (winnerIndex, gameStats, game) => ({
  winnerIndex,
  gameStats,
  finalGame: sanitizeGameForClient(game),
});
```

All four endings go through it, so a new way for a game to end carries the final board by construction rather than by remembering. Given this is the second time the same field was missed, that seemed worth more than a one-line patch.

`sanitizeGameForClient` is unchanged and still strips the credential maps, so the revealed game exposes the board without leaking tokens, uids, or socket ids.

## Testing

- Two new tests in `lzqgame.test.ts`: the payload carries the final board, and it strips `playerToTokenMap` / `playerToUidMap` / `playerToSocketIdMap`
- Full suite: 10 suites, 146 tests passing (was 144)
- `tsc --noEmit` clean

## Note on scope

The branch this fixes is defensive — `winnerByStalemate` normally ends the game on the preceding move, which exits through a path that already sent `finalGame`. The two checks can disagree, though: the stalemate check runs `hasLegalMoves` against the unfogged board passing only `flyingBombs`, while `chooseAiMove` runs against the fogged board with `landminesSurvive` as well. Reconciling those two legal-move searches is a separate question from the reveal and isn't touched here.